### PR TITLE
Auto-detect public node address

### DIFF
--- a/charge/servers/FLASKv2_reactions.py
+++ b/charge/servers/FLASKv2_reactions.py
@@ -89,7 +89,7 @@ def predict_reaction_internal(data: List[str], retrosynthesis: bool) -> List[str
 @click.option("--model-dir-retro", envvar="FLASKV2_MODEL_RETRO", help="Path to flaskv2 model for retrosynthesis")
 @click.option("--adapter-weights-fwd", help="LoRA adapter weights, if used")
 @click.option("--adapter-weights-retro", help="LoRA adapter weights for retrosynthesis model, if used")
-@click.option("--port", type=int, default=8001, help="Port to run the server on")
+@click.option("--port", type=int, default=8125, help="Port to run the server on")
 @click.option("--host", type=str, default=None, help="Host to run the server on")
 def main(model_dir_fwd: str, adapter_weights_fwd: str, model_dir_retro: str, adapter_weights_retro: str, port: str, host: Optional[str]):
     if not model_dir_fwd and not model_dir_retro:

--- a/charge/servers/server_utils.py
+++ b/charge/servers/server_utils.py
@@ -31,3 +31,15 @@ def get_hostname():
     hostname = socket.gethostname()
     host = socket.gethostbyname(hostname)
     return hostname, host
+
+def try_get_public_hostname():
+    import socket
+    hostname = socket.gethostname()
+    try:
+        public_hostname = hostname + "-pub"
+        host = socket.gethostbyname(public_hostname)
+        hostname = public_hostname
+    except socket.gaierror as e:
+        host = socket.gethostbyname(hostname)
+
+    return hostname, host


### PR DESCRIPTION
Add a function to auto-detect the public IP address on a cluster
front-end node. If undetected, fall back to the default IP address.