### PR TITLE
Add generic RSA (Recursive Self-Aggregation) algorithm framework

### DIFF
--- a/charge/__init__.py
+++ b/charge/__init__.py
@@ -1,2 +1,15 @@
 from charge._tags import verifier, hypothesis
 from charge._utils import enable_cmd_history_and_shell_integration
+
+# Make algorithms available at top level
+from charge.algorithms import run_rsa_loop, RSAConfig, RSACallbacks, RSATaskFactories
+
+__all__ = [
+    "verifier",
+    "hypothesis",
+    "enable_cmd_history_and_shell_integration",
+    "run_rsa_loop",
+    "RSAConfig",
+    "RSACallbacks",
+    "RSATaskFactories",
+]

--- a/charge/__init__.py
+++ b/charge/__init__.py
@@ -2,7 +2,7 @@ from charge._tags import verifier, hypothesis
 from charge._utils import enable_cmd_history_and_shell_integration
 
 # Make algorithms available at top level
-from charge.algorithms import run_rsa_loop, RSAConfig, RSACallbacks, RSATaskFactories
+from charge.algorithms import run_rsa_loop, RSAConfig, RSAPrompts, RSACallbacks, RSATaskFactories
 
 __all__ = [
     "verifier",
@@ -10,6 +10,7 @@ __all__ = [
     "enable_cmd_history_and_shell_integration",
     "run_rsa_loop",
     "RSAConfig",
+    "RSAPrompts",
     "RSACallbacks",
     "RSATaskFactories",
 ]

--- a/charge/__init__.py
+++ b/charge/__init__.py
@@ -2,7 +2,17 @@ from charge._tags import verifier, hypothesis
 from charge._utils import enable_cmd_history_and_shell_integration
 
 # Make algorithms available at top level
-from charge.algorithms import run_rsa_loop, RSAConfig, RSAPrompts, RSACallbacks, RSATaskFactories
+from charge.algorithms import (
+    run_rsa_loop,
+    RSAConfig,
+    RSAPrompts,
+    RSACallbacks,
+    RSATaskFactories,
+    GenericRSAOutput,
+    default_format_candidates,
+    create_default_proposal_task,
+    create_default_aggregation_task,
+)
 
 __all__ = [
     "verifier",
@@ -13,4 +23,8 @@ __all__ = [
     "RSAPrompts",
     "RSACallbacks",
     "RSATaskFactories",
+    "GenericRSAOutput",
+    "default_format_candidates",
+    "create_default_proposal_task",
+    "create_default_aggregation_task",
 ]

--- a/charge/__init__.py
+++ b/charge/__init__.py
@@ -3,11 +3,7 @@ from charge._utils import enable_cmd_history_and_shell_integration
 
 # Make algorithms available at top level
 from charge.algorithms import (
-    run_rsa_loop,
-    RSAConfig,
-    RSAPrompts,
-    RSACallbacks,
-    RSATaskFactories,
+    RSATask,
     GenericRSAOutput,
     default_format_candidates,
     create_default_proposal_task,
@@ -18,11 +14,7 @@ __all__ = [
     "verifier",
     "hypothesis",
     "enable_cmd_history_and_shell_integration",
-    "run_rsa_loop",
-    "RSAConfig",
-    "RSAPrompts",
-    "RSACallbacks",
-    "RSATaskFactories",
+    "RSATask",
     "GenericRSAOutput",
     "default_format_candidates",
     "create_default_proposal_task",

--- a/charge/algorithms/README.md
+++ b/charge/algorithms/README.md
@@ -1,0 +1,91 @@
+# ChARGe Algorithms
+
+This module provides generic algorithms that work with ChARGe tasks.
+
+## Recursive Self-Aggregation (RSA)
+
+The RSA algorithm generates N diverse proposals and recursively aggregates them T times using K-subset sampling to find high-quality solutions.
+
+### Basic Usage with Default Prompts
+
+```python
+from charge.algorithms import run_rsa_loop, RSAConfig, RSACallbacks, RSATaskFactories
+
+# Configure RSA
+config = RSAConfig(n=8, k=4, t=3)
+
+# Setup callbacks (uses defaults if omitted)
+callbacks = RSACallbacks()
+
+# Create task factories
+factories = RSATaskFactories(
+    create_proposal_task=lambda: YourTask(...),
+    create_aggregation_task=lambda candidates, subset, step, total: YourAggTask(...),
+    format_candidates=lambda subset: format_to_text(subset),
+    output_schema=YourOutputSchema,
+)
+
+# Run RSA
+output, result = await run_rsa_loop(
+    config=config,
+    factories=factories,
+    callbacks=callbacks,
+    runner=your_runner,
+)
+```
+
+### Using Custom Domain-Specific Prompts
+
+The default prompts are task-agnostic. For domain-specific tasks (chemistry, biology, etc.), you can provide custom prompts:
+
+```python
+from charge.algorithms import RSAPrompts
+
+# Option 1: Load from files
+chemistry_prompts = RSAPrompts(
+    proposal_system_prompt=Path("chemistry_system.txt").read_text(),
+    aggregation_template=Path("chemistry_aggregation.txt").read_text(),
+)
+
+# Option 2: Provide strings directly
+chemistry_prompts = RSAPrompts(
+    proposal_system_prompt="You are a chemistry expert...",
+    aggregation_template="Synthesize {candidates} into a better solution...",
+)
+
+# Pass to factories
+factories = RSATaskFactories(
+    ...,
+    prompts=chemistry_prompts,  # Use domain-specific prompts
+)
+```
+
+### Default Prompts
+
+ChARGe provides task-agnostic default prompts in `charge/algorithms/prompts/`:
+- `default_proposal_system.txt` - Generic problem-solving system prompt
+- `default_aggregation_template.txt` - Generic aggregation template
+
+These work out-of-the-box for any task but can be swapped for domain-specific prompts.
+
+### Aggregation Template Placeholders
+
+The aggregation template supports these placeholders:
+- `{original_prompt}` - The original user prompt
+- `{candidates}` - Formatted candidate solutions
+- `{step}` - Current aggregation step (2..T)
+- `{total_steps}` - Total number of steps (T)
+
+## Components
+
+### RSAConfig
+Algorithm parameters: `n` (proposals), `k` (subset size), `t` (stages), `parallel` (bool), `log_dir` (path)
+
+### RSAPrompts
+Prompt configuration: `proposal_system_prompt`, `aggregation_template`
+
+### RSACallbacks
+Logging hooks: `log_progress`, `logger_info`, `logger_warning`, `logger_error`
+
+### RSATaskFactories
+Task creation logic: `create_proposal_task`, `create_aggregation_task`, `format_candidates`, `output_schema`, `validate_proposal`, `prompts`

--- a/charge/algorithms/README.md
+++ b/charge/algorithms/README.md
@@ -34,29 +34,67 @@ output, result = await run_rsa_loop(
 )
 ```
 
-### Using Custom Domain-Specific Prompts
-
-The default prompts are task-agnostic. For domain-specific tasks (chemistry, biology, etc.), you can provide custom prompts:
-
 ```python
 from charge.algorithms import RSAPrompts
+from pydantic import BaseModel
+from typing import List
 
-# Option 1: Load from files
+# Example: Chemistry retrosynthesis customization
+
+# 1. Define custom output schema
+class ChemistryOutput(BaseModel):
+    reasoning_summary: str
+    reactants_smiles_list: List[str]
+    products_smiles_list: List[str]
+
+# 2. Load custom prompts
 chemistry_prompts = RSAPrompts(
     proposal_system_prompt=Path("chemistry_system.txt").read_text(),
     aggregation_template=Path("chemistry_aggregation.txt").read_text(),
 )
 
-# Option 2: Provide strings directly
-chemistry_prompts = RSAPrompts(
-    proposal_system_prompt="You are a chemistry expert...",
-    aggregation_template="Synthesize {candidates} into a better solution...",
-)
+# 3. Create custom formatter
+def format_chemistry_candidates(proposals):
+    text = ""
+    for idx, prop in enumerate(proposals, 1):
+        result = prop["result"]
+        text += f"\n---- Candidate {idx} ----\n"
+        text += f"Reasoning: {result.reasoning_summary}\n"
+        text += f"Reactants: {', '.join(result.reactants_smiles_list)}\n"
+        text += f"Products: {', '.join(result.products_smiles_list)}\n"
+    return text
 
-# Pass to factories
+# 4. Create custom validator
+def validate_chemistry(result):
+    return (hasattr(result, 'reactants_smiles_list') and
+            len(result.reactants_smiles_list) > 0)
+
+# 5. Use with RSA
 factories = RSATaskFactories(
-    ...,
-    prompts=chemistry_prompts,  # Use domain-specific prompts
+    user_prompt="Synthesize aspirin from...",
+    output_schema=ChemistryOutput,
+    format_candidates=format_chemistry_candidates,
+    validate_proposal=validate_chemistry,
+    prompts=chemistry_prompts,
+    builtin_tools=[verify_smiles, ...],  # Domain tools
+)
+```
+
+Or provide fully custom task factories:
+
+```python
+# For maximum control, provide custom task creation functions
+def create_my_proposal_task():
+    return MyDomainTask(...)
+
+def create_my_aggregation_task(candidates, subset, step, total):
+    return MyAggregationTask(...)
+
+factories = RSATaskFactories(
+    create_proposal_task=create_my_proposal_task,
+    create_aggregation_task=create_my_aggregation_task,
+    format_candidates=my_formatter,
+    output_schema=MySchema,
 )
 ```
 

--- a/charge/algorithms/README.md
+++ b/charge/algorithms/README.md
@@ -1,129 +1,166 @@
-# ChARGe Algorithms
+# ChARGe RSA Algorithm
 
-This module provides generic algorithms that work with ChARGe tasks.
+Recursive Self-Aggregation (RSA): Generate N diverse proposals, recursively aggregate K-subset samples across T stages.
 
-## Recursive Self-Aggregation (RSA)
-
-The RSA algorithm generates N diverse proposals and recursively aggregates them T times using K-subset sampling to find high-quality solutions.
-
-### Basic Usage with Default Prompts
+## Minimal Working Example
 
 ```python
+import asyncio
 from charge.algorithms import run_rsa_loop, RSAConfig, RSACallbacks, RSATaskFactories
+from charge.experiment import Experiment
 
-# Configure RSA
-config = RSAConfig(n=8, k=4, t=3)
+async def main():
+    # Create experiment and agent
+    experiment = Experiment(name="rsa_example")
+    runner = experiment.create_agent_with_experiment_state(
+        task=None,
+        agent_name="rsa_agent"
+    )
 
-# Setup callbacks (uses defaults if omitted)
-callbacks = RSACallbacks()
+    # Configure RSA (N=4 proposals, K=2 subset size, T=2 stages)
+    config = RSAConfig(n=4, k=2, t=2)
 
-# Create task factories
-factories = RSATaskFactories(
-    create_proposal_task=lambda: YourTask(...),
-    create_aggregation_task=lambda candidates, subset, step, total: YourAggTask(...),
-    format_candidates=lambda subset: format_to_text(subset),
-    output_schema=YourOutputSchema,
-)
+    # Create task factories with defaults (no customization needed)
+    factories = RSATaskFactories(
+        user_prompt="What are three solutions to reduce traffic congestion?"
+    )
 
-# Run RSA
-output, result = await run_rsa_loop(
-    config=config,
-    factories=factories,
-    callbacks=callbacks,
-    runner=your_runner,
-)
+    # Setup callbacks
+    callbacks = RSACallbacks()
+
+    # Run RSA
+    output, result = await run_rsa_loop(
+        config=config,
+        factories=factories,
+        callbacks=callbacks,
+        runner=runner,
+    )
+
+    print(f"Final result: {result.solution}")
+
+asyncio.run(main())
 ```
+
+That's it. RSA works out-of-the-box with sensible defaults.
+
+## Customization
+
+### 3-Part Prompt Structure
+
+RSA uses three prompts:
+1. **`system_prompt`**: Domain expert definition (same for proposals and aggregations)
+2. **`proposal_prompt`**: Task instructions for generating solutions
+3. **`aggregation_prompt`**: Task instructions for evaluating/synthesizing solutions
 
 ```python
 from charge.algorithms import RSAPrompts
+from pathlib import Path
+
+# Load custom prompts
+prompts = RSAPrompts(
+    system_prompt="You are an expert chemist specializing in retrosynthesis.",
+    proposal_prompt=Path("proposal_task.txt").read_text(),
+    aggregation_prompt=Path("aggregation_task.txt").read_text(),
+)
+
+factories = RSATaskFactories(
+    user_prompt="Synthesize aspirin from basic precursors",
+    prompts=prompts,
+)
+```
+
+### Custom Output Schema
+
+```python
 from pydantic import BaseModel
 from typing import List
 
-# Example: Chemistry retrosynthesis customization
-
-# 1. Define custom output schema
 class ChemistryOutput(BaseModel):
     reasoning_summary: str
     reactants_smiles_list: List[str]
     products_smiles_list: List[str]
 
-# 2. Load custom prompts
-chemistry_prompts = RSAPrompts(
-    proposal_system_prompt=Path("chemistry_system.txt").read_text(),
-    aggregation_template=Path("chemistry_aggregation.txt").read_text(),
+factories = RSATaskFactories(
+    user_prompt="Provide retrosynthesis for CC(=O)Oc1ccccc1C(=O)O",
+    output_schema=ChemistryOutput,
+    prompts=prompts,
 )
+```
 
-# 3. Create custom formatter
-def format_chemistry_candidates(proposals):
+### Custom Formatter and Validator
+
+```python
+def format_candidates(subset):
+    """Format proposals for aggregation"""
     text = ""
-    for idx, prop in enumerate(proposals, 1):
+    for idx, prop in enumerate(subset, 1):
         result = prop["result"]
         text += f"\n---- Candidate {idx} ----\n"
         text += f"Reasoning: {result.reasoning_summary}\n"
         text += f"Reactants: {', '.join(result.reactants_smiles_list)}\n"
-        text += f"Products: {', '.join(result.products_smiles_list)}\n"
     return text
 
-# 4. Create custom validator
-def validate_chemistry(result):
+def validate_proposal(result):
+    """Check if proposal is valid"""
     return (hasattr(result, 'reactants_smiles_list') and
             len(result.reactants_smiles_list) > 0)
 
-# 5. Use with RSA
 factories = RSATaskFactories(
-    user_prompt="Synthesize aspirin from...",
+    user_prompt="...",
     output_schema=ChemistryOutput,
-    format_candidates=format_chemistry_candidates,
-    validate_proposal=validate_chemistry,
-    prompts=chemistry_prompts,
-    builtin_tools=[verify_smiles, ...],  # Domain tools
+    prompts=prompts,
+    format_candidates=format_candidates,
+    validate_proposal=validate_proposal,
 )
 ```
 
-Or provide fully custom task factories:
+### Adding Tools
 
 ```python
-# For maximum control, provide custom task creation functions
-def create_my_proposal_task():
-    return MyDomainTask(...)
-
-def create_my_aggregation_task(candidates, subset, step, total):
-    return MyAggregationTask(...)
+from your_tools import verify_smiles, canonicalize_smiles
 
 factories = RSATaskFactories(
-    create_proposal_task=create_my_proposal_task,
-    create_aggregation_task=create_my_aggregation_task,
-    format_candidates=my_formatter,
-    output_schema=MySchema,
+    user_prompt="...",
+    output_schema=ChemistryOutput,
+    prompts=prompts,
+    builtin_tools=[verify_smiles, canonicalize_smiles],  # Direct tool functions
+    server_urls=["http://localhost:8000/mcp"],           # MCP server URLs
 )
 ```
-
-### Default Prompts
-
-ChARGe provides task-agnostic default prompts in `charge/algorithms/prompts/`:
-- `default_proposal_system.txt` - Generic problem-solving system prompt
-- `default_aggregation_template.txt` - Generic aggregation template
-
-These work out-of-the-box for any task but can be swapped for domain-specific prompts.
-
-### Aggregation Template Placeholders
-
-The aggregation template supports these placeholders:
-- `{original_prompt}` - The original user prompt
-- `{candidates}` - Formatted candidate solutions
-- `{step}` - Current aggregation step (2..T)
-- `{total_steps}` - Total number of steps (T)
 
 ## Components
 
 ### RSAConfig
-Algorithm parameters: `n` (proposals), `k` (subset size), `t` (stages), `parallel` (bool), `log_dir` (path)
+- `n`: Number of initial proposals (default: 8)
+- `k`: Subset size for aggregation (default: 4)
+- `t`: Number of stages (default: 3)
+- `parallel`: Run proposals in parallel (default: True)
+- `log_dir`: Directory for execution logs (default: auto-generated)
 
 ### RSAPrompts
-Prompt configuration: `proposal_system_prompt`, `aggregation_template`
+- `system_prompt`: Domain expert (e.g., "You are an expert chemist")
+- `proposal_prompt`: Generation task instructions
+- `aggregation_prompt`: Evaluation task instructions (supports `{original_prompt}`, `{candidates}`, `{step}`, `{total_steps}`)
 
 ### RSACallbacks
-Logging hooks: `log_progress`, `logger_info`, `logger_warning`, `logger_error`
+- `log_progress`: Progress callback for UI updates
+- `logger_info`, `logger_warning`, `logger_error`: Logging functions
 
 ### RSATaskFactories
-Task creation logic: `create_proposal_task`, `create_aggregation_task`, `format_candidates`, `output_schema`, `validate_proposal`, `prompts`
+- `user_prompt`: The problem to solve (required)
+- `prompts`: Custom RSAPrompts (optional, uses generic defaults)
+- `output_schema`: Pydantic model for validation (optional, uses GenericRSAOutput)
+- `format_candidates`: Function to format proposals for aggregation (optional)
+- `validate_proposal`: Function to check proposal validity (optional)
+- `builtin_tools`: Direct tool functions (optional)
+- `server_urls`: MCP server URLs (optional)
+- `**task_kwargs`: Additional Task parameters
+
+## Default Prompts
+
+ChARGe provides generic defaults in `charge/algorithms/prompts/`:
+- `default_proposal_system.txt` - Generic expert definition
+- `default_proposal_prompt.txt` - Generic generation task
+- `default_aggregation_prompt.txt` - Generic evaluation task
+
+These work for any problem but should be replaced with domain-specific prompts for best results.

--- a/charge/algorithms/README.md
+++ b/charge/algorithms/README.md
@@ -1,166 +1,205 @@
 # ChARGe RSA Algorithm
 
-Recursive Self-Aggregation (RSA): Generate N diverse proposals, recursively aggregate K-subset samples across T stages.
+Recursive Self-Aggregation (RSA): generate N diverse proposals, then for T-1 stages aggregate K-subsets of the current pool into improved candidates. Reference: <https://arxiv.org/pdf/2509.26626>.
 
-## Minimal Working Example
+The algorithm is exposed as a single `RSATask` class that extends `charge.tasks.Task`. It is domain-agnostic out of the box and can be specialized by subclassing.
+
+## Minimal Working Example (no subclassing)
 
 ```python
 import asyncio
-from charge.algorithms import run_rsa_loop, RSAConfig, RSACallbacks, RSATaskFactories
-from charge.experiment import Experiment
+from charge.algorithms import RSATask
+from charge.experiments.experiment import Experiment
 
 async def main():
-    # Create experiment and agent
     experiment = Experiment(name="rsa_example")
     runner = experiment.create_agent_with_experiment_state(
         task=None,
-        agent_name="rsa_agent"
+        agent_name="rsa_agent",
     )
 
-    # Configure RSA (N=4 proposals, K=2 subset size, T=2 stages)
-    config = RSAConfig(n=4, k=2, t=2)
-
-    # Create task factories with defaults (no customization needed)
-    factories = RSATaskFactories(
-        user_prompt="What are three solutions to reduce traffic congestion?"
+    task = RSATask(
+        n=4, k=2, t=2,
+        user_prompt="What are three solutions to reduce traffic congestion?",
     )
 
-    # Setup callbacks
-    callbacks = RSACallbacks()
-
-    # Run RSA
-    output, result = await run_rsa_loop(
-        config=config,
-        factories=factories,
-        callbacks=callbacks,
-        runner=runner,
-    )
-
-    print(f"Final result: {result.solution}")
+    output, result = await task.run_rsa(runner)
+    print(f"Final solution: {result.solution}")
 
 asyncio.run(main())
 ```
 
-That's it. RSA works out-of-the-box with sensible defaults.
+That's it. RSA works out of the box with sensible defaults. `result` is a `GenericRSAOutput` with `reasoning` and `solution` fields.
+
+## Cross-Domain Reuse
+
+Because every hook on `RSATask` has a working default, the same class fits any prompt-and-aggregate problem with no chemistry-specific code:
+
+```python
+# Short-story brainstorming
+task = RSATask(
+    n=6, k=3, t=3,
+    system_prompt="You are an award-winning fiction editor.",
+    proposal_prompt=(
+        "Pitch one original short story premise. Keep it under 80 words. "
+        "Specify protagonist, setting, central conflict, and a single "
+        "irresistible hook."
+    ),
+    aggregation_prompt=(
+        "Original brief: {original_prompt}\n\n"
+        "Candidate premises (Step {step} of {total_steps}):\n{candidates}\n\n"
+        "Combine the strongest elements into one improved premise."
+    ),
+    user_prompt="A story about an unexpected return.",
+)
+output, result = await task.run_rsa(runner)
+```
+
+```python
+# Math problem solving with a custom output schema
+from pydantic import BaseModel
+
+class MathSolution(BaseModel):
+    reasoning: str
+    answer: str
+    confidence: float
+
+task = RSATask(
+    n=8, k=4, t=2,
+    user_prompt="Find x: 3*x**2 - 12*x + 7 = 0.",
+    structured_output_schema=MathSolution,
+)
+output, result = await task.run_rsa(runner)
+print(result.answer, result.confidence)
+```
+
+No subclassing required for either. The default `format_candidates` introspects any Pydantic schema; the default validator accepts all results.
 
 ## Customization
 
-### 3-Part Prompt Structure
+Subclass `RSATask` only when you need domain-specific behavior. Override one or more hooks:
 
-RSA uses three prompts:
-1. **`system_prompt`**: Domain expert definition (same for proposals and aggregations)
-2. **`proposal_prompt`**: Task instructions for generating solutions
-3. **`aggregation_prompt`**: Task instructions for evaluating/synthesizing solutions
-
-```python
-from charge.algorithms import RSAPrompts
-from pathlib import Path
-
-# Load custom prompts
-prompts = RSAPrompts(
-    system_prompt="You are an expert chemist specializing in retrosynthesis.",
-    proposal_prompt=Path("proposal_task.txt").read_text(),
-    aggregation_prompt=Path("aggregation_task.txt").read_text(),
-)
-
-factories = RSATaskFactories(
-    user_prompt="Synthesize aspirin from basic precursors",
-    prompts=prompts,
-)
-```
-
-### Custom Output Schema
+| Hook | Default behavior | Override to |
+|---|---|---|
+| `format_candidates(subset)` | Introspects Pydantic schema, formats every field | Emit a domain-shaped candidates block (e.g. chemistry with reactants/products) |
+| `validate_proposal(result)` | Accept all | Reject proposals missing required structure |
+| `build_proposal_task()` | Combine `proposal_prompt` + `user_prompt` into a `Task` | Inject per-call context (RAG, prior turns) before building the Task |
+| `build_aggregation_task(text, step)` | Format `aggregation_prompt` template | Use a different Task subclass or aggregation strategy |
 
 ```python
+from charge.algorithms import RSATask
 from pydantic import BaseModel
-from typing import List
 
 class ChemistryOutput(BaseModel):
     reasoning_summary: str
-    reactants_smiles_list: List[str]
-    products_smiles_list: List[str]
+    reactants_smiles_list: list[str]
+    products_smiles_list: list[str]
 
-factories = RSATaskFactories(
-    user_prompt="Provide retrosynthesis for CC(=O)Oc1ccccc1C(=O)O",
-    output_schema=ChemistryOutput,
-    prompts=prompts,
-)
-```
+class RetroRSATask(RSATask):
+    def __init__(self, **kw):
+        kw.setdefault("structured_output_schema", ChemistryOutput)
+        super().__init__(**kw)
 
-### Custom Formatter and Validator
+    def format_candidates(self, subset):
+        out = ""
+        for idx, prop in enumerate(subset, 1):
+            r = prop["result"]
+            out += f"\n---- Candidate {idx} ----\n"
+            out += f"Reasoning: {r.reasoning_summary}\n"
+            out += f"Reactants: {', '.join(r.reactants_smiles_list)}\n"
+            out += f"Products: {', '.join(r.products_smiles_list)}\n"
+        return out
 
-```python
-def format_candidates(subset):
-    """Format proposals for aggregation"""
-    text = ""
-    for idx, prop in enumerate(subset, 1):
-        result = prop["result"]
-        text += f"\n---- Candidate {idx} ----\n"
-        text += f"Reasoning: {result.reasoning_summary}\n"
-        text += f"Reactants: {', '.join(result.reactants_smiles_list)}\n"
-    return text
-
-def validate_proposal(result):
-    """Check if proposal is valid"""
-    return (hasattr(result, 'reactants_smiles_list') and
-            len(result.reactants_smiles_list) > 0)
-
-factories = RSATaskFactories(
-    user_prompt="...",
-    output_schema=ChemistryOutput,
-    prompts=prompts,
-    format_candidates=format_candidates,
-    validate_proposal=validate_proposal,
-)
+    def validate_proposal(self, result):
+        return len(getattr(result, "reactants_smiles_list", [])) > 0
 ```
 
 ### Adding Tools
 
-```python
-from your_tools import verify_smiles, canonicalize_smiles
+`Task` keyword arguments (e.g. `server_urls`, `builtin_tools`, `bearer_token`) are forwarded through `RSATask.__init__` and reused for every proposal / aggregation Task constructed by the defaults:
 
-factories = RSATaskFactories(
+```python
+task = RSATask(
+    n=4, k=2, t=2,
     user_prompt="...",
-    output_schema=ChemistryOutput,
-    prompts=prompts,
-    builtin_tools=[verify_smiles, canonicalize_smiles],  # Direct tool functions
-    server_urls=["http://localhost:8000/mcp"],           # MCP server URLs
+    server_urls=["http://localhost:8000/mcp"],
+    builtin_tools=[verify_smiles, canonicalize_smiles],
+    bearer_token="...",
 )
 ```
 
-## Components
+### Parallel Execution
 
-### RSAConfig
-- `n`: Number of initial proposals (default: 8)
-- `k`: Subset size for aggregation (default: 4)
-- `t`: Number of stages (default: 3)
-- `parallel`: Run proposals in parallel (default: True)
-- `log_dir`: Directory for execution logs (default: auto-generated)
+Pass a `runner_factory` to `run_rsa()` to enable parallel proposals and parallel per-stage aggregations:
 
-### RSAPrompts
-- `system_prompt`: Domain expert (e.g., "You are an expert chemist")
-- `proposal_prompt`: Generation task instructions
-- `aggregation_prompt`: Evaluation task instructions (supports `{original_prompt}`, `{candidates}`, `{step}`, `{total_steps}`)
+```python
+def make_runner():
+    return experiment.create_agent_with_experiment_state(
+        task=None,
+        agent_name=f"proposal_runner",
+    )
 
-### RSACallbacks
-- `log_progress`: Progress callback for UI updates
-- `logger_info`, `logger_warning`, `logger_error`: Logging functions
+output, result = await task.run_rsa(runner, runner_factory=make_runner)
+```
 
-### RSATaskFactories
-- `user_prompt`: The problem to solve (required)
-- `prompts`: Custom RSAPrompts (optional, uses generic defaults)
-- `output_schema`: Pydantic model for validation (optional, uses GenericRSAOutput)
-- `format_candidates`: Function to format proposals for aggregation (optional)
-- `validate_proposal`: Function to check proposal validity (optional)
-- `builtin_tools`: Direct tool functions (optional)
-- `server_urls`: MCP server URLs (optional)
-- `**task_kwargs`: Additional Task parameters
+Without `runner_factory`, the loop runs sequentially even when `parallel=True`.
+
+### Custom Progress / Logging
+
+```python
+async def info(msg): await my_ui.send(f"[INFO] {msg}")
+async def warn(msg): await my_ui.send(f"[WARN] {msg}")
+
+output, result = await task.run_rsa(
+    runner,
+    log_progress=my_streaming_callback,
+    logger_info=info,
+    logger_warning=warn,
+)
+```
+
+When omitted, RSA falls back to `print()` for info/warn/error.
+
+## RSATask Reference
+
+```python
+RSATask(
+    n: int,                      # number of initial proposals (>=2)
+    k: int,                      # aggregation subset size (>=2, <=n)
+    t: int,                      # total stages (>=2)
+    *,
+    user_prompt: str | None,           # problem to solve (required for default build_*_task)
+    system_prompt: str | None,         # default: generic expert
+    proposal_prompt: str | None,       # default: loaded from prompts/default_proposal_system.txt
+    aggregation_prompt: str | None,    # default: loaded from prompts/default_aggregation_template.txt
+    structured_output_schema: type | None,  # default: GenericRSAOutput
+    parallel: bool = True,             # parallel proposals/aggregations when runner_factory given
+    log_dir: str | None,               # default: /tmp/rsa_execution_<timestamp>
+    disable_validation: bool = False,  # skip schema validation; also via CHARGE_DISABLE_OUTPUT_VALIDATION=1
+    **task_kwargs,                     # forwarded to underlying Task
+)
+
+await task.run_rsa(
+    runner,
+    *,
+    runner_factory=None,         # required for true parallel execution
+    log_progress=None,           # per-token streaming callback
+    logger_info=None,            # async info logger; default print() to stdout
+    logger_warning=None,         # async warning logger; default print() to stderr
+    logger_error=None,           # reserved
+    callback_handler=None,       # optional handler with awaitable .drain()
+) -> tuple[str, BaseModel]       # (raw_output_json, validated_result)
+```
 
 ## Default Prompts
 
-ChARGe provides generic defaults in `charge/algorithms/prompts/`:
-- `default_proposal_system.txt` - Generic expert definition
-- `default_proposal_prompt.txt` - Generic generation task
-- `default_aggregation_prompt.txt` - Generic evaluation task
+ChARGe ships generic defaults in `charge/algorithms/prompts/`:
 
-These work for any problem but should be replaced with domain-specific prompts for best results.
+- `default_proposal_system.txt` — generic problem-solver prompt
+- `default_aggregation_template.txt` — generic aggregation template with `{original_prompt}`, `{candidates}`, `{step}`, `{total_steps}` placeholders
+
+These work for any problem but are usually replaced with domain-specific prompts for best results.
+
+## Standalone helpers
+
+`create_default_proposal_task(user_prompt, ...)` and `create_default_aggregation_task(original_user_prompt, candidates_text, step, total_steps, ...)` are also exported for callers that want a single Task without running the loop.

--- a/charge/algorithms/__init__.py
+++ b/charge/algorithms/__init__.py
@@ -12,6 +12,10 @@ from charge.algorithms.rsa import (
     RSAPrompts,
     RSACallbacks,
     RSATaskFactories,
+    GenericRSAOutput,
+    default_format_candidates,
+    create_default_proposal_task,
+    create_default_aggregation_task,
 )
 
 __all__ = [
@@ -20,4 +24,8 @@ __all__ = [
     "RSAPrompts",
     "RSACallbacks",
     "RSATaskFactories",
+    "GenericRSAOutput",
+    "default_format_candidates",
+    "create_default_proposal_task",
+    "create_default_aggregation_task",
 ]

--- a/charge/algorithms/__init__.py
+++ b/charge/algorithms/__init__.py
@@ -9,6 +9,7 @@ Currently includes:
 from charge.algorithms.rsa import (
     run_rsa_loop,
     RSAConfig,
+    RSAPrompts,
     RSACallbacks,
     RSATaskFactories,
 )
@@ -16,6 +17,7 @@ from charge.algorithms.rsa import (
 __all__ = [
     "run_rsa_loop",
     "RSAConfig",
+    "RSAPrompts",
     "RSACallbacks",
     "RSATaskFactories",
 ]

--- a/charge/algorithms/__init__.py
+++ b/charge/algorithms/__init__.py
@@ -1,0 +1,21 @@
+"""
+ChARGe Algorithms Module
+
+This module provides generic algorithms that work with ChARGe tasks.
+Currently includes:
+- RSA (Recursive Self-Aggregation): N-K-T algorithm for proposal generation and aggregation
+"""
+
+from charge.algorithms.rsa import (
+    run_rsa_loop,
+    RSAConfig,
+    RSACallbacks,
+    RSATaskFactories,
+)
+
+__all__ = [
+    "run_rsa_loop",
+    "RSAConfig",
+    "RSACallbacks",
+    "RSATaskFactories",
+]

--- a/charge/algorithms/__init__.py
+++ b/charge/algorithms/__init__.py
@@ -1,17 +1,13 @@
-"""
-ChARGe Algorithms Module
+"""ChARGe algorithms.
 
-This module provides generic algorithms that work with ChARGe tasks.
-Currently includes:
-- RSA (Recursive Self-Aggregation): N-K-T algorithm for proposal generation and aggregation
+Currently provides:
+
+- RSA (Recursive Self-Aggregation): an N-K-T proposal-and-aggregation loop,
+  exposed as a :class:`Task` subclass for direct use with any ChARGe runner.
 """
 
 from charge.algorithms.rsa import (
-    run_rsa_loop,
-    RSAConfig,
-    RSAPrompts,
-    RSACallbacks,
-    RSATaskFactories,
+    RSATask,
     GenericRSAOutput,
     default_format_candidates,
     create_default_proposal_task,
@@ -19,11 +15,7 @@ from charge.algorithms.rsa import (
 )
 
 __all__ = [
-    "run_rsa_loop",
-    "RSAConfig",
-    "RSAPrompts",
-    "RSACallbacks",
-    "RSATaskFactories",
+    "RSATask",
     "GenericRSAOutput",
     "default_format_candidates",
     "create_default_proposal_task",

--- a/charge/algorithms/prompts/default_aggregation_template.txt
+++ b/charge/algorithms/prompts/default_aggregation_template.txt
@@ -1,0 +1,21 @@
+You are aggregating multiple candidate solutions to produce an improved solution.
+
+Original problem:
+{original_prompt}
+
+Candidate solutions (Step {step} of {total_steps}):
+{candidates}
+
+Your task:
+- Review all candidate solutions carefully
+- Identify strengths and weaknesses in each approach
+- Look for common patterns or complementary insights
+- Synthesize this information to produce a single, improved solution
+
+Requirements:
+- Your solution should be better than any individual candidate
+- Incorporate the best ideas from multiple candidates
+- Ensure your solution addresses the original problem completely
+- Use the same output format as the candidates
+
+Produce a single aggregated solution.

--- a/charge/algorithms/prompts/default_proposal_system.txt
+++ b/charge/algorithms/prompts/default_proposal_system.txt
@@ -1,0 +1,10 @@
+You are an expert problem solver using systematic reasoning and available tools.
+
+Your task is to generate a high-quality solution to the problem provided by the user. Follow these principles:
+- Break down complex problems into manageable steps
+- Use available tools to verify your solution
+- Consider multiple approaches before settling on one
+- Ensure your solution is complete and addresses all requirements
+- Provide clear reasoning for your approach
+
+Output your solution in the specified format.

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -237,6 +237,7 @@ def create_default_aggregation_task(
     step: int,
     total_steps: int,
     aggregation_template: Optional[str] = None,
+    system_prompt: Optional[str] = None,
     output_schema: Optional[type[BaseModel]] = None,
     **task_kwargs
 ) -> Any:
@@ -248,10 +249,11 @@ def create_default_aggregation_task(
     Args:
         original_user_prompt: The original problem/question
         candidates_text: Formatted candidate solutions
-        subset: List of candidate proposal dicts (unused in generic version)
+        subset: list of candidate proposal dicts (unused in generic version)
         step: Current aggregation step (2..T)
         total_steps: Total number of steps (T)
         aggregation_template: Optional override for template (uses default if None)
+        system_prompt: Optional system prompt for aggregations (uses default if None)
         output_schema: Optional output schema (uses GenericRSAOutput if None)
         **task_kwargs: Additional arguments passed to Task
 
@@ -282,8 +284,9 @@ def create_default_aggregation_task(
         total_steps=total_steps,
     )
 
-    # Use same system prompt as proposals (could be customized separately)
-    system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text() if _DEFAULT_PROPOSAL_SYSTEM.exists() else None
+    # Use provided system prompt or default to generic prompt
+    if system_prompt is None:
+        system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text() if _DEFAULT_PROPOSAL_SYSTEM.exists() else None
 
     task = Task(
         system_prompt=system_prompt,
@@ -388,6 +391,7 @@ class RSATaskFactories(Generic[T]):
                 step=step,
                 total_steps=total_steps,
                 aggregation_template=self.prompts.aggregation_template,
+                system_prompt=self.prompts.proposal_system_prompt,  # ← ADDED: Pass chemistry prompt
                 output_schema=self.output_schema,
                 **self.task_kwargs
             )

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 
 # Type variable for output schemas
-T = TypeVar('T')
+T = TypeVar("T")
 
 # Default prompt paths
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
@@ -40,6 +40,7 @@ class GenericRSAOutput(BaseModel):
         reasoning: Explanation of the approach and solution
         solution: The proposed solution as a string
     """
+
     reasoning: str
     solution: str
 
@@ -56,6 +57,7 @@ class RSAConfig:
         log_dir: Directory to save execution logs (default: /tmp/rsa_execution_{timestamp})
         disable_validation: If True, skip output schema validation (default: False)
     """
+
     n: int
     k: int
     t: int
@@ -79,6 +81,7 @@ class RSAConfig:
 
         if self.log_dir is None:
             import datetime
+
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             self.log_dir = f"/tmp/rsa_execution_{timestamp}"
 
@@ -97,6 +100,7 @@ class RSAPrompts:
         aggregation_prompt: Task-specific instructions for aggregation (uses {original_prompt},
                            {candidates}, {step}, {total_steps} placeholders)
     """
+
     system_prompt: Optional[str] = None
     proposal_prompt: Optional[str] = None
     aggregation_prompt: Optional[str] = None
@@ -104,9 +108,7 @@ class RSAPrompts:
     def __post_init__(self):
         """Load default prompts if not provided."""
         if self.system_prompt is None:
-            self.system_prompt = (
-                "You are an expert problem solver using systematic reasoning and available tools."
-            )
+            self.system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
 
         if self.proposal_prompt is None:
             if _DEFAULT_PROPOSAL_SYSTEM.exists():
@@ -170,11 +172,13 @@ class RSACallbacks:
     async def _default_logger_warning(self, message: str):
         """Default warning logger - print to stderr."""
         import sys
+
         print(f"[RSA Warning] {message}", file=sys.stderr)
 
     async def _default_logger_error(self, message: str):
         """Default error logger - print to stderr."""
         import sys
+
         print(f"[RSA Error] {message}", file=sys.stderr)
 
 
@@ -198,7 +202,7 @@ def default_format_candidates(proposals: list[dict]) -> str:
         # Format all fields from the schema
         for field_name, field_value in prop_result.model_dump().items():
             # Format field name nicely (snake_case -> Title Case)
-            display_name = field_name.replace('_', ' ').title()
+            display_name = field_name.replace("_", " ").title()
             candidates_text += f"{display_name}: {field_value}\n"
 
     return candidates_text
@@ -209,7 +213,7 @@ def create_default_proposal_task(
     system_prompt: Optional[str] = None,
     proposal_prompt: Optional[str] = None,
     output_schema: Optional[type[BaseModel]] = None,
-    **task_kwargs
+    **task_kwargs,
 ) -> Any:
     """Create a generic proposal task using default prompts.
 
@@ -244,7 +248,7 @@ def create_default_proposal_task(
         system_prompt=system_prompt,
         user_prompt=combined_user_prompt,
         structured_output_schema=output_schema,
-        **task_kwargs
+        **task_kwargs,
     )
 
     return task
@@ -259,7 +263,7 @@ def create_default_aggregation_task(
     aggregation_prompt: Optional[str] = None,
     system_prompt: Optional[str] = None,
     output_schema: Optional[type[BaseModel]] = None,
-    **task_kwargs
+    **task_kwargs,
 ) -> Any:
     """Create a generic aggregation task using default template.
 
@@ -312,7 +316,7 @@ def create_default_aggregation_task(
         system_prompt=system_prompt,
         user_prompt=user_prompt,
         structured_output_schema=output_schema,
-        **task_kwargs
+        **task_kwargs,
     )
 
     return task
@@ -330,12 +334,14 @@ class RSATaskFactories(Generic[T]):
         self,
         user_prompt: Optional[str] = None,
         create_proposal_task: Optional[Callable[[], Any]] = None,
-        create_aggregation_task: Optional[Callable[[str, list[dict], int, int], Any]] = None,
+        create_aggregation_task: Optional[
+            Callable[[str, list[dict], int, int], Any]
+        ] = None,
         format_candidates: Optional[Callable[[list[dict]], str]] = None,
         output_schema: Optional[type[T]] = None,
         validate_proposal: Optional[Callable[[Any], bool]] = None,
         prompts: Optional[RSAPrompts] = None,
-        **task_kwargs
+        **task_kwargs,
     ):
         """Initialize task factories with optional overrides.
 
@@ -392,19 +398,26 @@ class RSATaskFactories(Generic[T]):
 
     def _create_default_proposal_factory(self) -> Callable[[], Any]:
         """Create a default proposal task factory."""
+
         def factory():
             return create_default_proposal_task(
                 user_prompt=self.user_prompt,
                 system_prompt=self.prompts.system_prompt,
                 proposal_prompt=self.prompts.proposal_prompt,
                 output_schema=self.output_schema,
-                **self.task_kwargs
+                **self.task_kwargs,
             )
+
         return factory
 
-    def _create_default_aggregation_factory(self) -> Callable[[str, list[dict], int, int], Any]:
+    def _create_default_aggregation_factory(
+        self,
+    ) -> Callable[[str, list[dict], int, int], Any]:
         """Create a default aggregation task factory."""
-        def factory(candidates_text: str, subset: list[dict], step: int, total_steps: int):
+
+        def factory(
+            candidates_text: str, subset: list[dict], step: int, total_steps: int
+        ):
             return create_default_aggregation_task(
                 original_user_prompt=self.user_prompt,
                 candidates_text=candidates_text,
@@ -414,8 +427,9 @@ class RSATaskFactories(Generic[T]):
                 aggregation_prompt=self.prompts.aggregation_prompt,
                 system_prompt=self.prompts.system_prompt,  # Same expert as proposals
                 output_schema=self.output_schema,
-                **self.task_kwargs
+                **self.task_kwargs,
             )
+
         return factory
 
     def _default_validator(self, result: Any) -> bool:
@@ -456,14 +470,19 @@ async def run_rsa_loop(
     async def run_single_proposal(proposal_index: int, proposal_runner: Any):
         """Run a single proposal and return result or None if failed"""
         try:
-            await callbacks.logger_info(f"Generating proposal {proposal_index+1}/{config.n}")
+            await callbacks.logger_info(
+                f"Generating proposal {proposal_index+1}/{config.n}"
+            )
 
             # Create proposal task
             proposal_task = factories.create_proposal_task()
             proposal_runner.task = proposal_task
 
             # Disable validation if requested
-            if config.disable_validation or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1":
+            if (
+                config.disable_validation
+                or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1"
+            ):
                 proposal_task.structured_output_schema = None
 
             # Save proposal prompt
@@ -472,7 +491,9 @@ async def run_rsa_loop(
                 "system_prompt": proposal_task.get_system_prompt(),
                 "user_prompt": proposal_task.get_user_prompt(),
             }
-            with open(f"{config.log_dir}/proposer_{proposal_index+1:02d}_prompt.json", "w") as f:
+            with open(
+                f"{config.log_dir}/proposer_{proposal_index+1:02d}_prompt.json", "w"
+            ) as f:
                 json.dump(proposer_log, f, indent=2)
 
             # Run proposal
@@ -481,37 +502,52 @@ async def run_rsa_loop(
                 await callback_handler.drain()
 
             # Validate output
-            proposal_result = factories.output_schema.model_validate_json(proposal_output)
+            proposal_result = factories.output_schema.model_validate_json(
+                proposal_output
+            )
 
             # Check if proposal is valid using custom validator
             if not factories.validate_proposal(proposal_result):
-                await callbacks.logger_warning(f"Proposal {proposal_index+1} failed validation (empty or invalid), skipping")
+                await callbacks.logger_warning(
+                    f"Proposal {proposal_index+1} failed validation (empty or invalid), skipping"
+                )
                 return None
 
             # Save proposal output
             proposer_output_log = {
                 "proposal_index": proposal_index + 1,
                 "result": proposal_result.model_dump(),
-                "full_output": json.loads(proposal_output)
+                "full_output": json.loads(proposal_output),
             }
-            with open(f"{config.log_dir}/proposer_{proposal_index+1:02d}_output.json", "w") as f:
+            with open(
+                f"{config.log_dir}/proposer_{proposal_index+1:02d}_output.json", "w"
+            ) as f:
                 json.dump(proposer_output_log, f, indent=2)
 
-            await callbacks.logger_info(f"Proposal {proposal_index+1} completed successfully")
+            await callbacks.logger_info(
+                f"Proposal {proposal_index+1} completed successfully"
+            )
 
             return {
                 "output": proposal_output,
                 "result": proposal_result,
-                "index": proposal_index
+                "index": proposal_index,
             }
 
+        except asyncio.CancelledError:
+            await callbacks.logger_warning(f"Proposal {proposal_index+1} was cancelled")
+            return None
         except Exception as e:
-            await callbacks.logger_warning(f"Proposal {proposal_index+1} failed: {str(e)}")
+            await callbacks.logger_warning(
+                f"Proposal {proposal_index+1} failed: {str(e)}"
+            )
             return None
 
     # Stage 1: Generate N initial proposals
-    await callbacks.logger_info(f"RSA Step 1/{config.t}: Generating {config.n} initial proposals" +
-                      (" (parallel mode)" if config.parallel else " (sequential mode)"))
+    await callbacks.logger_info(
+        f"RSA Step 1/{config.t}: Generating {config.n} initial proposals"
+        + (" (parallel mode)" if config.parallel else " (sequential mode)")
+    )
 
     if config.parallel and runner_factory:
         # Parallel mode: generate all proposals concurrently
@@ -529,13 +565,17 @@ async def run_rsa_loop(
         proposals = []
         for i, result in enumerate(proposal_results):
             if isinstance(result, Exception):
-                await callbacks.logger_warning(f"Proposal {i+1} failed with exception: {str(result)}")
+                await callbacks.logger_warning(
+                    f"Proposal {i+1} failed with exception: {str(result)}"
+                )
             elif result is not None:
                 proposals.append(result)
     else:
         # Sequential mode: generate proposals one by one
         if config.parallel and not runner_factory:
-            await callbacks.logger_warning("Parallel mode requested but no runner_factory provided, falling back to sequential")
+            await callbacks.logger_warning(
+                "Parallel mode requested but no runner_factory provided, falling back to sequential"
+            )
 
         proposals = []
         for i in range(config.n):
@@ -549,7 +589,9 @@ async def run_rsa_loop(
     await callbacks.logger_info(f"Generated {len(proposals)} valid proposals")
 
     # Helper function to run a single aggregation
-    async def run_single_aggregation(agg_index: int, step: int, current_proposals: list, agg_runner: Any):
+    async def run_single_aggregation(
+        agg_index: int, step: int, current_proposals: list, agg_runner: Any
+    ):
         """Run a single aggregation and return result or None if failed"""
         try:
             # Adjust K if needed
@@ -569,14 +611,14 @@ async def run_rsa_loop(
 
             # Create aggregation task
             agg_task = factories.create_aggregation_task(
-                candidates_text,
-                subset,
-                step,
-                config.t
+                candidates_text, subset, step, config.t
             )
             agg_runner.task = agg_task
 
-            if config.disable_validation or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1":
+            if (
+                config.disable_validation
+                or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1"
+            ):
                 agg_task.structured_output_schema = None
 
             # Save aggregation prompt
@@ -588,7 +630,10 @@ async def run_rsa_loop(
                 "user_prompt": agg_task.get_user_prompt(),
                 "candidates_text": candidates_text,
             }
-            with open(f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_prompt.json", "w") as f:
+            with open(
+                f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_prompt.json",
+                "w",
+            ) as f:
                 json.dump(aggregator_log, f, indent=2)
 
             # Run aggregation
@@ -601,7 +646,9 @@ async def run_rsa_loop(
 
             # Check if aggregation is valid using custom validator
             if not factories.validate_proposal(agg_result):
-                await callbacks.logger_warning(f"Aggregation {agg_index+1} (Step {step}) failed validation (empty or invalid), skipping")
+                await callbacks.logger_warning(
+                    f"Aggregation {agg_index+1} (Step {step}) failed validation (empty or invalid), skipping"
+                )
                 return None
 
             # Save aggregation output
@@ -610,33 +657,47 @@ async def run_rsa_loop(
                 "aggregation_index": agg_index + 1,
                 "k_subset_indices": subset_indices,
                 "result": agg_result.model_dump(),
-                "full_output": json.loads(agg_output)
+                "full_output": json.loads(agg_output),
             }
-            with open(f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_output.json", "w") as f:
+            with open(
+                f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_output.json",
+                "w",
+            ) as f:
                 json.dump(aggregator_output_log, f, indent=2)
 
-            await callbacks.logger_info(f"Aggregation {agg_index+1} (Step {step}) completed successfully")
+            await callbacks.logger_info(
+                f"Aggregation {agg_index+1} (Step {step}) completed successfully"
+            )
 
             return {
                 "output": agg_output,
                 "result": agg_result,
                 "index": agg_index,
-                "step": step
+                "step": step,
             }
 
+        except asyncio.CancelledError:
+            await callbacks.logger_warning(
+                f"Aggregation {agg_index+1} (Step {step}) was cancelled"
+            )
+            return None
         except Exception as e:
-            await callbacks.logger_warning(f"Aggregation {agg_index+1} (Step {step}) failed: {str(e)}")
+            await callbacks.logger_warning(
+                f"Aggregation {agg_index+1} (Step {step}) failed: {str(e)}"
+            )
             return None
 
     # Stages 2-T: Recursive aggregation
     # BARRIER: Wait for all Stage 1 proposals to complete before starting Stage 2
     current_proposals = proposals
-    await callbacks.logger_info(f"Stage 1 complete. Generated {len(proposals)} valid proposals.")
+    await callbacks.logger_info(
+        f"Stage 1 complete. Generated {len(proposals)} valid proposals."
+    )
 
     for step in range(2, config.t + 1):
         await callbacks.logger_info(
-            f"RSA Step {step}/{config.t}: Aggregating {len(current_proposals)} proposals into {k}-subsets" +
-            (" (parallel mode)" if config.parallel else " (sequential mode)")
+            f"RSA Step {step}/{config.t}: Aggregating {len(current_proposals)} proposals into {k}-subsets"
+            + (" (parallel mode)" if config.parallel else " (sequential mode)")
         )
 
         # Log if K needs adjustment due to insufficient proposals
@@ -665,28 +726,38 @@ async def run_rsa_loop(
             next_proposals = []
             for i, result in enumerate(agg_results):
                 if isinstance(result, Exception):
-                    await callbacks.logger_warning(f"Aggregation {i+1} (Step {step}) failed with exception: {str(result)}")
+                    await callbacks.logger_warning(
+                        f"Aggregation {i+1} (Step {step}) failed with exception: {str(result)}"
+                    )
                 elif result is not None:
                     next_proposals.append(result)
 
         else:
             # Sequential mode: run aggregations one by one
             if config.parallel and not runner_factory:
-                await callbacks.logger_warning("Parallel mode requested but no runner_factory provided, falling back to sequential")
+                await callbacks.logger_warning(
+                    "Parallel mode requested but no runner_factory provided, falling back to sequential"
+                )
 
             next_proposals = []
             for i in range(num_aggregations):
-                result = await run_single_aggregation(i, step, current_proposals, runner)
+                result = await run_single_aggregation(
+                    i, step, current_proposals, runner
+                )
                 if result is not None:
                     next_proposals.append(result)
 
         if not next_proposals:
-            await callbacks.logger_warning(f"No successful aggregations in step {step}, using previous proposals")
+            await callbacks.logger_warning(
+                f"No successful aggregations in step {step}, using previous proposals"
+            )
             break
 
         # BARRIER: All aggregations in current stage complete before moving to next stage
         current_proposals = next_proposals
-        await callbacks.logger_info(f"Stage {step} complete. Generated {len(current_proposals)} valid aggregations.")
+        await callbacks.logger_info(
+            f"Stage {step} complete. Generated {len(current_proposals)} valid aggregations."
+        )
 
     # Select final proposal (first one from final stage)
     if not current_proposals:
@@ -707,6 +778,8 @@ async def run_rsa_loop(
     log_path = Path(config.log_dir) / "FINAL_OUTPUT.json"
     log_path.write_text(json.dumps(final_log, indent=2))
 
-    await callbacks.logger_info(f"RSA completed! Final output saved to {config.log_dir}")
+    await callbacks.logger_info(
+        f"RSA completed! Final output saved to {config.log_dir}"
+    )
 
     return final_output, final_result

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -65,8 +65,17 @@ class RSAConfig:
 
     def __post_init__(self):
         """Validate configuration parameters and set defaults."""
-        if self.n < 1 or self.k < 1 or self.t < 1:
-            raise ValueError(f"Invalid RSA parameters: N={self.n}, K={self.k}, T={self.t} (all must be >= 1)")
+        if self.n < 2 or self.k < 2 or self.t < 2:
+            raise ValueError(
+                f"Invalid RSA parameters: N={self.n}, K={self.k}, T={self.t}. "
+                f"All must be >= 2. (T=1 would skip aggregation, defeating RSA's purpose)"
+            )
+
+        if self.k > self.n:
+            raise ValueError(
+                f"Invalid RSA parameters: K ({self.k}) cannot be greater than N ({self.n}). "
+                f"K is the subset size for aggregation and must be <= N (number of proposals)."
+            )
 
         if self.log_dir is None:
             import datetime
@@ -440,12 +449,8 @@ async def run_rsa_loop(
     Raises:
         ValueError: If all proposals fail or invalid parameters
     """
-
-    # Validate K <= N
+    # K validation happens in RSAConfig.__post_init__
     k = config.k
-    if k > config.n:
-        await callbacks.logger_warning(f"K ({k}) > N ({config.n}), adjusting K to N")
-        k = config.n
 
     # Helper function to run a single proposal
     async def run_single_proposal(proposal_index: int, proposal_runner: Any):
@@ -634,13 +639,11 @@ async def run_rsa_loop(
             (" (parallel mode)" if config.parallel else " (sequential mode)")
         )
 
-        # Adjust K if needed
-        current_k = k
+        # Log if K needs adjustment due to insufficient proposals
         if len(current_proposals) < k:
             await callbacks.logger_warning(
-                f"Not enough proposals ({len(current_proposals)}) for K={k}, using all available"
+                f"Step {step}: Only {len(current_proposals)} proposals available, K will be adjusted from {k} to {len(current_proposals)} for this stage"
             )
-            current_k = len(current_proposals)
 
         # Generate aggregations
         num_aggregations = max(config.n, len(current_proposals))

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -1,0 +1,436 @@
+"""
+Recursive Self-Aggregation (RSA) Algorithm
+
+This module provides the core N-K-T RSA loop that can be used by any task type
+(retrosynthesis, LMO, etc.) through customizable factory functions and formatters.
+
+RSA Algorithm:
+    Stage 1: Generate N diverse proposals
+    Stages 2-T: Recursively aggregate K-subset proposals
+    Output: Single best proposal from final stage
+"""
+
+import random
+import json
+import os
+import asyncio
+from typing import Any, Callable, Optional, TypeVar, Generic
+from pathlib import Path
+from dataclasses import dataclass
+
+
+# Type variable for output schemas
+T = TypeVar('T')
+
+
+@dataclass
+class RSAConfig:
+    """Configuration for RSA algorithm execution.
+
+    Attributes:
+        n: Number of initial proposals to generate
+        k: Size of subsets for aggregation (K <= N)
+        t: Total number of stages (including initial proposals)
+        parallel: If True, generate proposals/aggregations in parallel (default: True)
+        log_dir: Directory to save execution logs (default: /tmp/rsa_execution_{timestamp})
+        disable_validation: If True, skip output schema validation (default: False)
+    """
+    n: int
+    k: int
+    t: int
+    parallel: bool = True
+    log_dir: Optional[str] = None
+    disable_validation: bool = False
+
+    def __post_init__(self):
+        """Validate configuration parameters and set defaults."""
+        if self.n < 1 or self.k < 1 or self.t < 1:
+            raise ValueError(f"Invalid RSA parameters: N={self.n}, K={self.k}, T={self.t} (all must be >= 1)")
+
+        if self.log_dir is None:
+            import datetime
+            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.log_dir = f"/tmp/rsa_execution_{timestamp}"
+
+        os.makedirs(self.log_dir, exist_ok=True)
+
+
+class RSACallbacks:
+    """Callbacks for RSA algorithm progress and logging.
+
+    These provide hooks for custom logging and UI updates during RSA execution.
+    All callbacks are async functions.
+    """
+
+    def __init__(
+        self,
+        log_progress: Optional[Callable[[str], Any]] = None,
+        logger_info: Optional[Callable[[str], Any]] = None,
+        logger_warning: Optional[Callable[[str], Any]] = None,
+        logger_error: Optional[Callable[[str], Any]] = None,
+    ):
+        """Initialize callbacks with optional custom implementations.
+
+        Args:
+            log_progress: Callback for reasoning progress (for LLM streaming)
+            logger_info: Info level logging callback
+            logger_warning: Warning level logging callback
+            logger_error: Error level logging callback
+        """
+        self.log_progress = log_progress or self._default_log_progress
+        self.logger_info = logger_info or self._default_logger_info
+        self.logger_warning = logger_warning or self._default_logger_warning
+        self.logger_error = logger_error or self._default_logger_error
+
+    async def _default_log_progress(self, message: str):
+        """Default progress logger - print to stdout."""
+        print(f"[RSA Progress] {message}")
+
+    async def _default_logger_info(self, message: str):
+        """Default info logger - print to stdout."""
+        print(f"[RSA Info] {message}")
+
+    async def _default_logger_warning(self, message: str):
+        """Default warning logger - print to stderr."""
+        import sys
+        print(f"[RSA Warning] {message}", file=sys.stderr)
+
+    async def _default_logger_error(self, message: str):
+        """Default error logger - print to stderr."""
+        import sys
+        print(f"[RSA Error] {message}", file=sys.stderr)
+
+
+class RSATaskFactories(Generic[T]):
+    """Factory functions for creating RSA tasks.
+
+    This class encapsulates the domain-specific task creation logic,
+    allowing RSA to work with any task type.
+    """
+
+    def __init__(
+        self,
+        create_proposal_task: Callable[[], Any],
+        create_aggregation_task: Callable[[str, list[dict], int, int], Any],
+        format_candidates: Callable[[list[dict]], str],
+        output_schema: type[T],
+        validate_proposal: Optional[Callable[[Any], bool]] = None,
+    ):
+        """Initialize task factories.
+
+        Args:
+            create_proposal_task: Factory that returns a Task for generating proposals.
+                                 Should return a fresh Task instance each time.
+            create_aggregation_task: Factory that returns a Task for aggregating proposals.
+                                    Takes (candidates_text, subset, step, total_steps).
+            format_candidates: Function to format proposals into text for aggregation.
+                              Takes list of proposal dicts, returns formatted string.
+            output_schema: Pydantic model class for validating task outputs.
+            validate_proposal: Optional function to validate a proposal result.
+                              Takes result object, returns True if valid.
+                              Used to filter out empty/invalid proposals.
+        """
+        self.create_proposal_task = create_proposal_task
+        self.create_aggregation_task = create_aggregation_task
+        self.format_candidates = format_candidates
+        self.output_schema = output_schema
+        self.validate_proposal = validate_proposal or self._default_validator
+
+    def _default_validator(self, result: Any) -> bool:
+        """Default validator - always returns True."""
+        return True
+
+
+async def run_rsa_loop(
+    config: RSAConfig,
+    factories: RSATaskFactories,
+    callbacks: RSACallbacks,
+    runner: Any,
+    runner_factory: Optional[Callable[[], Any]] = None,
+    callback_handler: Optional[Any] = None,
+) -> tuple[str, Any]:
+    """
+    Execute the generic N-K-T RSA algorithm.
+
+    Args:
+        config: RSA configuration (n, k, t, parallel, log_dir)
+        factories: Task factory functions for proposal and aggregation
+        callbacks: Logging and progress callbacks
+        runner: ChARGe agent runner with .task and .run() interface
+        runner_factory: Factory to create independent runner instances for parallel execution.
+                       If None and parallel=True, falls back to sequential execution.
+        callback_handler: Optional callback handler to drain after each task
+
+    Returns:
+        tuple: (final_output_json, final_result_object)
+
+    Raises:
+        ValueError: If all proposals fail or invalid parameters
+    """
+
+    # Validate K <= N
+    k = config.k
+    if k > config.n:
+        await callbacks.logger_warning(f"K ({k}) > N ({config.n}), adjusting K to N")
+        k = config.n
+
+    # Helper function to run a single proposal
+    async def run_single_proposal(proposal_index: int, proposal_runner: Any):
+        """Run a single proposal and return result or None if failed"""
+        try:
+            await callbacks.logger_info(f"Generating proposal {proposal_index+1}/{config.n}")
+
+            # Create proposal task
+            proposal_task = factories.create_proposal_task()
+            proposal_runner.task = proposal_task
+
+            # Disable validation if requested
+            if config.disable_validation or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1":
+                proposal_task.structured_output_schema = None
+
+            # Save proposal prompt
+            proposer_log = {
+                "proposal_index": proposal_index + 1,
+                "system_prompt": proposal_task.get_system_prompt(),
+                "user_prompt": proposal_task.get_user_prompt(),
+            }
+            with open(f"{config.log_dir}/proposer_{proposal_index+1:02d}_prompt.json", "w") as f:
+                json.dump(proposer_log, f, indent=2)
+
+            # Run proposal
+            proposal_output = await proposal_runner.run(callbacks.log_progress)
+            if callback_handler:
+                await callback_handler.drain()
+
+            # Validate output
+            proposal_result = factories.output_schema.model_validate_json(proposal_output)
+
+            # Check if proposal is valid using custom validator
+            if not factories.validate_proposal(proposal_result):
+                await callbacks.logger_warning(f"Proposal {proposal_index+1} failed validation (empty or invalid), skipping")
+                return None
+
+            # Save proposal output
+            proposer_output_log = {
+                "proposal_index": proposal_index + 1,
+                "result": proposal_result.model_dump(),
+                "full_output": json.loads(proposal_output)
+            }
+            with open(f"{config.log_dir}/proposer_{proposal_index+1:02d}_output.json", "w") as f:
+                json.dump(proposer_output_log, f, indent=2)
+
+            await callbacks.logger_info(f"Proposal {proposal_index+1} completed successfully")
+
+            return {
+                "output": proposal_output,
+                "result": proposal_result,
+                "index": proposal_index
+            }
+
+        except Exception as e:
+            await callbacks.logger_warning(f"Proposal {proposal_index+1} failed: {str(e)}")
+            return None
+
+    # Stage 1: Generate N initial proposals
+    await callbacks.logger_info(f"RSA Step 1/{config.t}: Generating {config.n} initial proposals" +
+                      (" (parallel mode)" if config.parallel else " (sequential mode)"))
+
+    if config.parallel and runner_factory:
+        # Parallel mode: generate all proposals concurrently
+        proposal_tasks = []
+        for i in range(config.n):
+            # Create independent runner for each proposal
+            proposal_runner = runner_factory()
+            task = run_single_proposal(i, proposal_runner)
+            proposal_tasks.append(task)
+
+        # Run all proposals in parallel
+        proposal_results = await asyncio.gather(*proposal_tasks, return_exceptions=True)
+
+        # Filter valid proposals and handle exceptions
+        proposals = []
+        for i, result in enumerate(proposal_results):
+            if isinstance(result, Exception):
+                await callbacks.logger_warning(f"Proposal {i+1} failed with exception: {str(result)}")
+            elif result is not None:
+                proposals.append(result)
+    else:
+        # Sequential mode: generate proposals one by one
+        if config.parallel and not runner_factory:
+            await callbacks.logger_warning("Parallel mode requested but no runner_factory provided, falling back to sequential")
+
+        proposals = []
+        for i in range(config.n):
+            result = await run_single_proposal(i, runner)
+            if result is not None:
+                proposals.append(result)
+
+    if not proposals:
+        raise ValueError("All RSA proposals failed")
+
+    await callbacks.logger_info(f"Generated {len(proposals)} valid proposals")
+
+    # Helper function to run a single aggregation
+    async def run_single_aggregation(agg_index: int, step: int, current_proposals: list, agg_runner: Any):
+        """Run a single aggregation and return result or None if failed"""
+        try:
+            # Adjust K if needed
+            current_k = k
+            if len(current_proposals) < k:
+                current_k = len(current_proposals)
+
+            # Select K random proposals
+            if len(current_proposals) <= current_k:
+                subset = current_proposals
+            else:
+                subset = random.sample(current_proposals, current_k)
+
+            # Format candidates using task-specific formatter
+            candidates_text = factories.format_candidates(subset)
+            subset_indices = [prop["index"] + 1 for prop in subset]
+
+            # Create aggregation task
+            agg_task = factories.create_aggregation_task(
+                candidates_text,
+                subset,
+                step,
+                config.t
+            )
+            agg_runner.task = agg_task
+
+            if config.disable_validation or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1":
+                agg_task.structured_output_schema = None
+
+            # Save aggregation prompt
+            aggregator_log = {
+                "step": step,
+                "aggregation_index": agg_index + 1,
+                "k_subset_indices": subset_indices,
+                "system_prompt": agg_task.get_system_prompt(),
+                "user_prompt": agg_task.get_user_prompt(),
+                "candidates_text": candidates_text,
+            }
+            with open(f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_prompt.json", "w") as f:
+                json.dump(aggregator_log, f, indent=2)
+
+            # Run aggregation
+            agg_output = await agg_runner.run(callbacks.log_progress)
+            if callback_handler:
+                await callback_handler.drain()
+
+            # Validate output
+            agg_result = factories.output_schema.model_validate_json(agg_output)
+
+            # Check if aggregation is valid using custom validator
+            if not factories.validate_proposal(agg_result):
+                await callbacks.logger_warning(f"Aggregation {agg_index+1} (Step {step}) failed validation (empty or invalid), skipping")
+                return None
+
+            # Save aggregation output
+            aggregator_output_log = {
+                "step": step,
+                "aggregation_index": agg_index + 1,
+                "k_subset_indices": subset_indices,
+                "result": agg_result.model_dump(),
+                "full_output": json.loads(agg_output)
+            }
+            with open(f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_output.json", "w") as f:
+                json.dump(aggregator_output_log, f, indent=2)
+
+            await callbacks.logger_info(f"Aggregation {agg_index+1} (Step {step}) completed successfully")
+
+            return {
+                "output": agg_output,
+                "result": agg_result,
+                "index": agg_index,
+                "step": step
+            }
+
+        except Exception as e:
+            await callbacks.logger_warning(f"Aggregation {agg_index+1} (Step {step}) failed: {str(e)}")
+            return None
+
+    # Stages 2-T: Recursive aggregation
+    # BARRIER: Wait for all Stage 1 proposals to complete before starting Stage 2
+    current_proposals = proposals
+    await callbacks.logger_info(f"Stage 1 complete. Generated {len(proposals)} valid proposals.")
+
+    for step in range(2, config.t + 1):
+        await callbacks.logger_info(
+            f"RSA Step {step}/{config.t}: Aggregating {len(current_proposals)} proposals into {k}-subsets" +
+            (" (parallel mode)" if config.parallel else " (sequential mode)")
+        )
+
+        # Adjust K if needed
+        current_k = k
+        if len(current_proposals) < k:
+            await callbacks.logger_warning(
+                f"Not enough proposals ({len(current_proposals)}) for K={k}, using all available"
+            )
+            current_k = len(current_proposals)
+
+        # Generate aggregations
+        num_aggregations = max(config.n, len(current_proposals))
+
+        if config.parallel and runner_factory:
+            # Parallel mode: run all aggregations in this stage concurrently
+            agg_tasks = []
+            for i in range(num_aggregations):
+                # Create independent runner for each aggregation
+                agg_runner = runner_factory()
+                task = run_single_aggregation(i, step, current_proposals, agg_runner)
+                agg_tasks.append(task)
+
+            # Run all aggregations in parallel and wait for all to complete
+            # BARRIER: asyncio.gather waits for all aggregations in this stage
+            agg_results = await asyncio.gather(*agg_tasks, return_exceptions=True)
+
+            # Filter valid aggregations and handle exceptions
+            next_proposals = []
+            for i, result in enumerate(agg_results):
+                if isinstance(result, Exception):
+                    await callbacks.logger_warning(f"Aggregation {i+1} (Step {step}) failed with exception: {str(result)}")
+                elif result is not None:
+                    next_proposals.append(result)
+
+        else:
+            # Sequential mode: run aggregations one by one
+            if config.parallel and not runner_factory:
+                await callbacks.logger_warning("Parallel mode requested but no runner_factory provided, falling back to sequential")
+
+            next_proposals = []
+            for i in range(num_aggregations):
+                result = await run_single_aggregation(i, step, current_proposals, runner)
+                if result is not None:
+                    next_proposals.append(result)
+
+        if not next_proposals:
+            await callbacks.logger_warning(f"No successful aggregations in step {step}, using previous proposals")
+            break
+
+        # BARRIER: All aggregations in current stage complete before moving to next stage
+        current_proposals = next_proposals
+        await callbacks.logger_info(f"Stage {step} complete. Generated {len(current_proposals)} valid aggregations.")
+
+    # Select final proposal (first one from final stage)
+    if not current_proposals:
+        raise ValueError("RSA failed to produce any valid proposals")
+
+    final_proposal = current_proposals[0]
+    final_output = final_proposal["output"]
+    final_result = final_proposal["result"]
+
+    # Save final output
+    final_log = {
+        "final_step": step if step <= config.t else config.t,
+        "n_proposals": config.n,
+        "k_subset_size": k,
+        "t_stages": config.t,
+        "final_result": final_result.model_dump(),
+    }
+    log_path = Path(config.log_dir) / "FINAL_OUTPUT.json"
+    log_path.write_text(json.dumps(final_log, indent=2))
+
+    await callbacks.logger_info(f"RSA completed! Final output saved to {config.log_dir}")
+
+    return final_output, final_result

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -83,32 +83,39 @@ class RSAPrompts:
     Provides default task-agnostic prompts that can be overridden for domain-specific use.
 
     Attributes:
-        proposal_system_prompt: System prompt for proposal generation tasks
-        aggregation_template: Template for aggregation prompts (uses {original_prompt},
-                             {candidates}, {step}, {total_steps} placeholders)
+        system_prompt: System prompt defining domain expert (used for both proposals and aggregations)
+        proposal_prompt: Task-specific instructions for proposal generation
+        aggregation_prompt: Task-specific instructions for aggregation (uses {original_prompt},
+                           {candidates}, {step}, {total_steps} placeholders)
     """
-    proposal_system_prompt: Optional[str] = None
-    aggregation_template: Optional[str] = None
+    system_prompt: Optional[str] = None
+    proposal_prompt: Optional[str] = None
+    aggregation_prompt: Optional[str] = None
 
     def __post_init__(self):
         """Load default prompts if not provided."""
-        if self.proposal_system_prompt is None:
+        if self.system_prompt is None:
+            self.system_prompt = (
+                "You are an expert problem solver using systematic reasoning and available tools."
+            )
+
+        if self.proposal_prompt is None:
             if _DEFAULT_PROPOSAL_SYSTEM.exists():
-                self.proposal_system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
+                # Load old default file for backward compatibility
+                self.proposal_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
             else:
                 # Fallback if file doesn't exist
-                self.proposal_system_prompt = (
-                    "You are an expert problem solver. Generate a high-quality solution "
-                    "to the problem provided by the user. Use available tools and provide "
-                    "clear reasoning."
+                self.proposal_prompt = (
+                    "Your task is to generate a high-quality solution to the problem. "
+                    "Use available tools and provide clear reasoning."
                 )
 
-        if self.aggregation_template is None:
+        if self.aggregation_prompt is None:
             if _DEFAULT_AGGREGATION_TEMPLATE.exists():
-                self.aggregation_template = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
+                self.aggregation_prompt = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
             else:
                 # Fallback if file doesn't exist
-                self.aggregation_template = (
+                self.aggregation_prompt = (
                     "You are aggregating multiple solutions.\n\n"
                     "Original problem:\n{original_prompt}\n\n"
                     "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
@@ -191,6 +198,7 @@ def default_format_candidates(proposals: list[dict]) -> str:
 def create_default_proposal_task(
     user_prompt: str,
     system_prompt: Optional[str] = None,
+    proposal_prompt: Optional[str] = None,
     output_schema: Optional[type[BaseModel]] = None,
     **task_kwargs
 ) -> Any:
@@ -201,7 +209,8 @@ def create_default_proposal_task(
 
     Args:
         user_prompt: The problem/question to solve
-        system_prompt: Optional override for system prompt (uses default if None)
+        system_prompt: Domain expert definition (e.g., "You are an expert chemist")
+        proposal_prompt: Task instructions for generating proposals
         output_schema: Optional output schema (uses GenericRSAOutput if None)
         **task_kwargs: Additional arguments passed to Task (server_urls, builtin_tools, etc.)
 
@@ -211,18 +220,20 @@ def create_default_proposal_task(
     from charge.tasks.task import Task
 
     if system_prompt is None:
-        # Load default proposal system prompt
-        if _DEFAULT_PROPOSAL_SYSTEM.exists():
-            system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
-        else:
-            system_prompt = "You are an expert problem solver. Generate a high-quality solution."
+        system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
+
+    if proposal_prompt is None:
+        proposal_prompt = "Your task is to generate a high-quality solution to the problem. Use available tools and provide clear reasoning."
+
+    # Combine proposal instructions with user's problem
+    combined_user_prompt = f"{proposal_prompt}\n\n{user_prompt}"
 
     if output_schema is None:
         output_schema = GenericRSAOutput
 
     task = Task(
         system_prompt=system_prompt,
-        user_prompt=user_prompt,
+        user_prompt=combined_user_prompt,
         structured_output_schema=output_schema,
         **task_kwargs
     )
@@ -236,7 +247,7 @@ def create_default_aggregation_task(
     subset: list[dict],
     step: int,
     total_steps: int,
-    aggregation_template: Optional[str] = None,
+    aggregation_prompt: Optional[str] = None,
     system_prompt: Optional[str] = None,
     output_schema: Optional[type[BaseModel]] = None,
     **task_kwargs
@@ -252,8 +263,9 @@ def create_default_aggregation_task(
         subset: list of candidate proposal dicts (unused in generic version)
         step: Current aggregation step (2..T)
         total_steps: Total number of steps (T)
-        aggregation_template: Optional override for template (uses default if None)
-        system_prompt: Optional system prompt for aggregations (uses default if None)
+        aggregation_prompt: Task instructions template for aggregation (uses {original_prompt},
+                           {candidates}, {step}, {total_steps} placeholders)
+        system_prompt: Domain expert definition (same as proposals)
         output_schema: Optional output schema (uses GenericRSAOutput if None)
         **task_kwargs: Additional arguments passed to Task
 
@@ -262,12 +274,15 @@ def create_default_aggregation_task(
     """
     from charge.tasks.task import Task
 
-    if aggregation_template is None:
+    if system_prompt is None:
+        system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
+
+    if aggregation_prompt is None:
         # Load default aggregation template
         if _DEFAULT_AGGREGATION_TEMPLATE.exists():
-            aggregation_template = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
+            aggregation_prompt = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
         else:
-            aggregation_template = (
+            aggregation_prompt = (
                 "Original problem:\n{original_prompt}\n\n"
                 "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
                 "Synthesize these into a single improved solution."
@@ -277,16 +292,12 @@ def create_default_aggregation_task(
         output_schema = GenericRSAOutput
 
     # Format the aggregation prompt
-    user_prompt = aggregation_template.format(
+    user_prompt = aggregation_prompt.format(
         original_prompt=original_user_prompt,
         candidates=candidates_text,
         step=step,
         total_steps=total_steps,
     )
-
-    # Use provided system prompt or default to generic prompt
-    if system_prompt is None:
-        system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text() if _DEFAULT_PROPOSAL_SYSTEM.exists() else None
 
     task = Task(
         system_prompt=system_prompt,
@@ -375,7 +386,8 @@ class RSATaskFactories(Generic[T]):
         def factory():
             return create_default_proposal_task(
                 user_prompt=self.user_prompt,
-                system_prompt=self.prompts.proposal_system_prompt,
+                system_prompt=self.prompts.system_prompt,
+                proposal_prompt=self.prompts.proposal_prompt,
                 output_schema=self.output_schema,
                 **self.task_kwargs
             )
@@ -390,8 +402,8 @@ class RSATaskFactories(Generic[T]):
                 subset=subset,
                 step=step,
                 total_steps=total_steps,
-                aggregation_template=self.prompts.aggregation_template,
-                system_prompt=self.prompts.proposal_system_prompt,  # ← ADDED: Pass chemistry prompt
+                aggregation_prompt=self.prompts.aggregation_prompt,
+                system_prompt=self.prompts.system_prompt,  # Same expert as proposals
                 output_schema=self.output_schema,
                 **self.task_kwargs
             )

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -16,11 +16,16 @@ import os
 import asyncio
 from typing import Any, Callable, Optional, TypeVar, Generic
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 # Type variable for output schemas
 T = TypeVar('T')
+
+# Default prompt paths
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
+_DEFAULT_PROPOSAL_SYSTEM = _PROMPTS_DIR / "default_proposal_system.txt"
+_DEFAULT_AGGREGATION_TEMPLATE = _PROMPTS_DIR / "default_aggregation_template.txt"
 
 
 @dataclass
@@ -53,6 +58,46 @@ class RSAConfig:
             self.log_dir = f"/tmp/rsa_execution_{timestamp}"
 
         os.makedirs(self.log_dir, exist_ok=True)
+
+
+@dataclass
+class RSAPrompts:
+    """Prompts for RSA proposal and aggregation tasks.
+
+    Provides default task-agnostic prompts that can be overridden for domain-specific use.
+
+    Attributes:
+        proposal_system_prompt: System prompt for proposal generation tasks
+        aggregation_template: Template for aggregation prompts (uses {original_prompt},
+                             {candidates}, {step}, {total_steps} placeholders)
+    """
+    proposal_system_prompt: Optional[str] = None
+    aggregation_template: Optional[str] = None
+
+    def __post_init__(self):
+        """Load default prompts if not provided."""
+        if self.proposal_system_prompt is None:
+            if _DEFAULT_PROPOSAL_SYSTEM.exists():
+                self.proposal_system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
+            else:
+                # Fallback if file doesn't exist
+                self.proposal_system_prompt = (
+                    "You are an expert problem solver. Generate a high-quality solution "
+                    "to the problem provided by the user. Use available tools and provide "
+                    "clear reasoning."
+                )
+
+        if self.aggregation_template is None:
+            if _DEFAULT_AGGREGATION_TEMPLATE.exists():
+                self.aggregation_template = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
+            else:
+                # Fallback if file doesn't exist
+                self.aggregation_template = (
+                    "You are aggregating multiple solutions.\n\n"
+                    "Original problem:\n{original_prompt}\n\n"
+                    "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
+                    "Synthesize these into a single improved solution."
+                )
 
 
 class RSACallbacks:
@@ -115,6 +160,7 @@ class RSATaskFactories(Generic[T]):
         format_candidates: Callable[[list[dict]], str],
         output_schema: type[T],
         validate_proposal: Optional[Callable[[Any], bool]] = None,
+        prompts: Optional[RSAPrompts] = None,
     ):
         """Initialize task factories.
 
@@ -129,12 +175,15 @@ class RSATaskFactories(Generic[T]):
             validate_proposal: Optional function to validate a proposal result.
                               Takes result object, returns True if valid.
                               Used to filter out empty/invalid proposals.
+            prompts: Optional RSAPrompts instance with custom prompts.
+                    If None, uses default task-agnostic prompts from ChARGe.
         """
         self.create_proposal_task = create_proposal_task
         self.create_aggregation_task = create_aggregation_task
         self.format_candidates = format_candidates
         self.output_schema = output_schema
         self.validate_proposal = validate_proposal or self._default_validator
+        self.prompts = prompts or RSAPrompts()
 
     def _default_validator(self, result: Any) -> bool:
         """Default validator - always returns True."""

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -14,9 +14,10 @@ import random
 import json
 import os
 import asyncio
-from typing import Any, Callable, Optional, TypeVar, Generic
+from typing import Any, Callable, Optional, TypeVar, Generic, List
 from pathlib import Path
 from dataclasses import dataclass, field
+from pydantic import BaseModel
 
 
 # Type variable for output schemas
@@ -26,6 +27,21 @@ T = TypeVar('T')
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _DEFAULT_PROPOSAL_SYSTEM = _PROMPTS_DIR / "default_proposal_system.txt"
 _DEFAULT_AGGREGATION_TEMPLATE = _PROMPTS_DIR / "default_aggregation_template.txt"
+
+
+# Generic default output schema
+class GenericRSAOutput(BaseModel):
+    """Generic output schema for RSA proposals and aggregations.
+
+    This provides a sensible default that works for any task.
+    Domain-specific implementations can define their own schemas.
+
+    Attributes:
+        reasoning: Explanation of the approach and solution
+        solution: The proposed solution as a string
+    """
+    reasoning: str
+    solution: str
 
 
 @dataclass
@@ -146,44 +162,236 @@ class RSACallbacks:
         print(f"[RSA Error] {message}", file=sys.stderr)
 
 
+def default_format_candidates(proposals: list[dict]) -> str:
+    """Generic formatter for RSA candidates.
+
+    Works with any Pydantic schema by extracting all fields and formatting them.
+    Domain-specific implementations can provide custom formatters.
+
+    Args:
+        proposals: List of proposal dicts with 'result' key containing validated output
+
+    Returns:
+        Formatted text suitable for aggregation prompts
+    """
+    candidates_text = ""
+    for idx, prop in enumerate(proposals, 1):
+        prop_result = prop["result"]
+        candidates_text += f"\n---- Candidate {idx} ----\n"
+
+        # Format all fields from the schema
+        for field_name, field_value in prop_result.model_dump().items():
+            # Format field name nicely (snake_case -> Title Case)
+            display_name = field_name.replace('_', ' ').title()
+            candidates_text += f"{display_name}: {field_value}\n"
+
+    return candidates_text
+
+
+def create_default_proposal_task(
+    user_prompt: str,
+    system_prompt: Optional[str] = None,
+    output_schema: Optional[type[BaseModel]] = None,
+    **task_kwargs
+) -> Any:
+    """Create a generic proposal task using default prompts.
+
+    This is a production-ready default that works for any problem.
+    Domain-specific implementations can provide custom task creation.
+
+    Args:
+        user_prompt: The problem/question to solve
+        system_prompt: Optional override for system prompt (uses default if None)
+        output_schema: Optional output schema (uses GenericRSAOutput if None)
+        **task_kwargs: Additional arguments passed to Task (server_urls, builtin_tools, etc.)
+
+    Returns:
+        Task instance configured for proposal generation
+    """
+    from charge.tasks.task import Task
+
+    if system_prompt is None:
+        # Load default proposal system prompt
+        if _DEFAULT_PROPOSAL_SYSTEM.exists():
+            system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
+        else:
+            system_prompt = "You are an expert problem solver. Generate a high-quality solution."
+
+    if output_schema is None:
+        output_schema = GenericRSAOutput
+
+    task = Task(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        structured_output_schema=output_schema,
+        **task_kwargs
+    )
+
+    return task
+
+
+def create_default_aggregation_task(
+    original_user_prompt: str,
+    candidates_text: str,
+    subset: list[dict],
+    step: int,
+    total_steps: int,
+    aggregation_template: Optional[str] = None,
+    output_schema: Optional[type[BaseModel]] = None,
+    **task_kwargs
+) -> Any:
+    """Create a generic aggregation task using default template.
+
+    This is a production-ready default that works for any problem.
+    Domain-specific implementations can provide custom task creation.
+
+    Args:
+        original_user_prompt: The original problem/question
+        candidates_text: Formatted candidate solutions
+        subset: List of candidate proposal dicts (unused in generic version)
+        step: Current aggregation step (2..T)
+        total_steps: Total number of steps (T)
+        aggregation_template: Optional override for template (uses default if None)
+        output_schema: Optional output schema (uses GenericRSAOutput if None)
+        **task_kwargs: Additional arguments passed to Task
+
+    Returns:
+        Task instance configured for aggregation
+    """
+    from charge.tasks.task import Task
+
+    if aggregation_template is None:
+        # Load default aggregation template
+        if _DEFAULT_AGGREGATION_TEMPLATE.exists():
+            aggregation_template = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
+        else:
+            aggregation_template = (
+                "Original problem:\n{original_prompt}\n\n"
+                "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
+                "Synthesize these into a single improved solution."
+            )
+
+    if output_schema is None:
+        output_schema = GenericRSAOutput
+
+    # Format the aggregation prompt
+    user_prompt = aggregation_template.format(
+        original_prompt=original_user_prompt,
+        candidates=candidates_text,
+        step=step,
+        total_steps=total_steps,
+    )
+
+    # Use same system prompt as proposals (could be customized separately)
+    system_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text() if _DEFAULT_PROPOSAL_SYSTEM.exists() else None
+
+    task = Task(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        structured_output_schema=output_schema,
+        **task_kwargs
+    )
+
+    return task
+
+
 class RSATaskFactories(Generic[T]):
     """Factory functions for creating RSA tasks.
 
-    This class encapsulates the domain-specific task creation logic,
-    allowing RSA to work with any task type.
+    This class encapsulates task creation logic. All parameters are optional
+    with production-ready defaults, allowing RSA to work out-of-box.
+    Domain-specific implementations can override any component.
     """
 
     def __init__(
         self,
-        create_proposal_task: Callable[[], Any],
-        create_aggregation_task: Callable[[str, list[dict], int, int], Any],
-        format_candidates: Callable[[list[dict]], str],
-        output_schema: type[T],
+        user_prompt: Optional[str] = None,
+        create_proposal_task: Optional[Callable[[], Any]] = None,
+        create_aggregation_task: Optional[Callable[[str, list[dict], int, int], Any]] = None,
+        format_candidates: Optional[Callable[[list[dict]], str]] = None,
+        output_schema: Optional[type[T]] = None,
         validate_proposal: Optional[Callable[[Any], bool]] = None,
         prompts: Optional[RSAPrompts] = None,
+        **task_kwargs
     ):
-        """Initialize task factories.
+        """Initialize task factories with optional overrides.
+
+        All parameters have sensible defaults for out-of-box usage.
 
         Args:
+            user_prompt: The problem/question to solve (required for default factories).
+                        Not needed if providing custom factories.
             create_proposal_task: Factory that returns a Task for generating proposals.
-                                 Should return a fresh Task instance each time.
+                                 If None, uses create_default_proposal_task.
             create_aggregation_task: Factory that returns a Task for aggregating proposals.
-                                    Takes (candidates_text, subset, step, total_steps).
+                                    If None, uses create_default_aggregation_task.
             format_candidates: Function to format proposals into text for aggregation.
-                              Takes list of proposal dicts, returns formatted string.
+                              If None, uses default_format_candidates.
             output_schema: Pydantic model class for validating task outputs.
+                          If None, uses GenericRSAOutput.
             validate_proposal: Optional function to validate a proposal result.
-                              Takes result object, returns True if valid.
-                              Used to filter out empty/invalid proposals.
+                              If None, accepts all proposals (returns True).
             prompts: Optional RSAPrompts instance with custom prompts.
                     If None, uses default task-agnostic prompts from ChARGe.
+            **task_kwargs: Additional arguments passed to Task instances
+                          (server_urls, builtin_tools, etc.)
         """
-        self.create_proposal_task = create_proposal_task
-        self.create_aggregation_task = create_aggregation_task
-        self.format_candidates = format_candidates
-        self.output_schema = output_schema
+        self.output_schema = output_schema or GenericRSAOutput
         self.validate_proposal = validate_proposal or self._default_validator
         self.prompts = prompts or RSAPrompts()
+        self.task_kwargs = task_kwargs
+        self.user_prompt = user_prompt
+
+        # Use provided factories or create defaults
+        if create_proposal_task is not None:
+            self.create_proposal_task = create_proposal_task
+        else:
+            # Create default factory using user_prompt
+            if user_prompt is None:
+                raise ValueError(
+                    "user_prompt is required when using default task factories. "
+                    "Either provide user_prompt or custom create_proposal_task/create_aggregation_task."
+                )
+            self.create_proposal_task = self._create_default_proposal_factory()
+
+        if create_aggregation_task is not None:
+            self.create_aggregation_task = create_aggregation_task
+        else:
+            # Create default factory
+            if user_prompt is None:
+                raise ValueError(
+                    "user_prompt is required when using default task factories. "
+                    "Either provide user_prompt or custom create_proposal_task/create_aggregation_task."
+                )
+            self.create_aggregation_task = self._create_default_aggregation_factory()
+
+        self.format_candidates = format_candidates or default_format_candidates
+
+    def _create_default_proposal_factory(self) -> Callable[[], Any]:
+        """Create a default proposal task factory."""
+        def factory():
+            return create_default_proposal_task(
+                user_prompt=self.user_prompt,
+                system_prompt=self.prompts.proposal_system_prompt,
+                output_schema=self.output_schema,
+                **self.task_kwargs
+            )
+        return factory
+
+    def _create_default_aggregation_factory(self) -> Callable[[str, list[dict], int, int], Any]:
+        """Create a default aggregation task factory."""
+        def factory(candidates_text: str, subset: list[dict], step: int, total_steps: int):
+            return create_default_aggregation_task(
+                original_user_prompt=self.user_prompt,
+                candidates_text=candidates_text,
+                subset=subset,
+                step=step,
+                total_steps=total_steps,
+                aggregation_template=self.prompts.aggregation_template,
+                output_schema=self.output_schema,
+                **self.task_kwargs
+            )
+        return factory
 
     def _default_validator(self, result: Any) -> bool:
         """Default validator - always returns True."""

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -363,7 +363,7 @@ class RSATaskFactories(Generic[T]):
             prompts: Optional RSAPrompts instance with custom prompts.
                     If None, uses default task-agnostic prompts from ChARGe.
             **task_kwargs: Additional arguments passed to Task instances
-                          (server_urls, builtin_tools, etc.)
+                          (server_urls, builtin_tools, bearer_token, etc.)
         """
         self.output_schema = output_schema or GenericRSAOutput
         self.validate_proposal = validate_proposal or self._default_validator

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -324,6 +324,15 @@ class RSATask(Task):
 
     # ---------------------- The N-K-T orchestrator ----------------------
 
+    async def run(self, runner, **kwargs):
+        """Polymorphic :meth:`Task.run` entry point for RSA.
+
+        Delegates to :meth:`run_rsa`, which drives the N-K-T loop. Exists so
+        callers can invoke RSA through the generic Task API
+        (``await rsa_task.run(runner, ...)``) without knowing it is RSA.
+        """
+        return await self.run_rsa(runner, **kwargs)
+
     async def run_rsa(
         self,
         runner: Any,

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -1,785 +1,686 @@
-"""
-Recursive Self-Aggregation (RSA) Algorithm
-https://arxiv.org/pdf/2509.26626
-This module provides the core N-K-T RSA loop that can be used by any task type
-(retrosynthesis, LMO, etc.) through customizable factory functions and formatters.
+"""Recursive Self-Aggregation (RSA) algorithm.
 
-RSA Algorithm:
-    Stage 1: Generate N diverse proposals
-    Stages 2-T: Recursively aggregate K-subset proposals
-    Output: Single best proposal from final stage
+Reference: https://arxiv.org/pdf/2509.26626
+
+Implements an N-K-T orchestration loop on top of the ChARGe Task interface:
+
+    Stage 1     : Generate N independent proposals from the same problem.
+    Stages 2..T : Repeatedly draw K-subsets of the current proposal pool and
+                  aggregate each subset into a single improved proposal.
+    Output      : Best proposal from the final stage.
+
+The algorithm is domain-agnostic. ``RSATask`` works out of the box for any
+prompt-and-aggregate problem using ``GenericRSAOutput`` as its schema. To
+specialize for a domain, subclass ``RSATask`` and override one or more of:
+
+    format_candidates(subset)        -> str
+    validate_proposal(result)        -> bool
+    build_proposal_task()            -> Task
+    build_aggregation_task(text, step) -> Task
 """
 
-import random
-import json
+from __future__ import annotations
+
 import os
+import json
+import random
 import asyncio
-from typing import Any, Callable, Optional, TypeVar, Generic, List
+import datetime
 from pathlib import Path
-from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional, Type
+
+import sys
 from pydantic import BaseModel
 
+from charge.tasks.task import Task
 
-# Type variable for output schemas
-T = TypeVar("T")
 
-# Default prompt paths
+# ----- module-level constants & defaults -----
+
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _DEFAULT_PROPOSAL_SYSTEM = _PROMPTS_DIR / "default_proposal_system.txt"
 _DEFAULT_AGGREGATION_TEMPLATE = _PROMPTS_DIR / "default_aggregation_template.txt"
 
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are an expert problem solver using systematic reasoning and "
+    "available tools."
+)
+_FALLBACK_PROPOSAL_PROMPT = (
+    "Your task is to generate a high-quality solution to the problem. "
+    "Use available tools and provide clear reasoning."
+)
+_FALLBACK_AGGREGATION_PROMPT = (
+    "You are aggregating multiple solutions.\n\n"
+    "Original problem:\n{original_prompt}\n\n"
+    "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
+    "Synthesize these into a single improved solution."
+)
 
-# Generic default output schema
+
 class GenericRSAOutput(BaseModel):
-    """Generic output schema for RSA proposals and aggregations.
+    """Default output schema for RSA proposals and aggregations.
 
-    This provides a sensible default that works for any task.
-    Domain-specific implementations can define their own schemas.
-
-    Attributes:
-        reasoning: Explanation of the approach and solution
-        solution: The proposed solution as a string
+    Domain-specific code can supply a richer Pydantic model via the
+    ``structured_output_schema`` parameter of :class:`RSATask`.
     """
 
     reasoning: str
     solution: str
 
 
-@dataclass
-class RSAConfig:
-    """Configuration for RSA algorithm execution.
-
-    Attributes:
-        n: Number of initial proposals to generate
-        k: Size of subsets for aggregation (K <= N)
-        t: Total number of stages (including initial proposals)
-        parallel: If True, generate proposals/aggregations in parallel (default: True)
-        log_dir: Directory to save execution logs (default: /tmp/rsa_execution_{timestamp})
-        disable_validation: If True, skip output schema validation (default: False)
-    """
-
-    n: int
-    k: int
-    t: int
-    parallel: bool = True
-    log_dir: Optional[str] = None
-    disable_validation: bool = False
-
-    def __post_init__(self):
-        """Validate configuration parameters and set defaults."""
-        if self.n < 2 or self.k < 2 or self.t < 2:
-            raise ValueError(
-                f"Invalid RSA parameters: N={self.n}, K={self.k}, T={self.t}. "
-                f"All must be >= 2. (T=1 would skip aggregation, defeating RSA's purpose)"
-            )
-
-        if self.k > self.n:
-            raise ValueError(
-                f"Invalid RSA parameters: K ({self.k}) cannot be greater than N ({self.n}). "
-                f"K is the subset size for aggregation and must be <= N (number of proposals)."
-            )
-
-        if self.log_dir is None:
-            import datetime
-
-            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            self.log_dir = f"/tmp/rsa_execution_{timestamp}"
-
-        os.makedirs(self.log_dir, exist_ok=True)
-
-
-@dataclass
-class RSAPrompts:
-    """Prompts for RSA proposal and aggregation tasks.
-
-    Provides default task-agnostic prompts that can be overridden for domain-specific use.
-
-    Attributes:
-        system_prompt: System prompt defining domain expert (used for both proposals and aggregations)
-        proposal_prompt: Task-specific instructions for proposal generation
-        aggregation_prompt: Task-specific instructions for aggregation (uses {original_prompt},
-                           {candidates}, {step}, {total_steps} placeholders)
-    """
-
-    system_prompt: Optional[str] = None
-    proposal_prompt: Optional[str] = None
-    aggregation_prompt: Optional[str] = None
-
-    def __post_init__(self):
-        """Load default prompts if not provided."""
-        if self.system_prompt is None:
-            self.system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
-
-        if self.proposal_prompt is None:
-            if _DEFAULT_PROPOSAL_SYSTEM.exists():
-                # Load old default file for backward compatibility
-                self.proposal_prompt = _DEFAULT_PROPOSAL_SYSTEM.read_text()
-            else:
-                # Fallback if file doesn't exist
-                self.proposal_prompt = (
-                    "Your task is to generate a high-quality solution to the problem. "
-                    "Use available tools and provide clear reasoning."
-                )
-
-        if self.aggregation_prompt is None:
-            if _DEFAULT_AGGREGATION_TEMPLATE.exists():
-                self.aggregation_prompt = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
-            else:
-                # Fallback if file doesn't exist
-                self.aggregation_prompt = (
-                    "You are aggregating multiple solutions.\n\n"
-                    "Original problem:\n{original_prompt}\n\n"
-                    "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
-                    "Synthesize these into a single improved solution."
-                )
-
-
-class RSACallbacks:
-    """Callbacks for RSA algorithm progress and logging.
-
-    These provide hooks for custom logging and UI updates during RSA execution.
-    All callbacks are async functions.
-    """
-
-    def __init__(
-        self,
-        log_progress: Optional[Callable[[str], Any]] = None,
-        logger_info: Optional[Callable[[str], Any]] = None,
-        logger_warning: Optional[Callable[[str], Any]] = None,
-        logger_error: Optional[Callable[[str], Any]] = None,
-    ):
-        """Initialize callbacks with optional custom implementations.
-
-        Args:
-            log_progress: Callback for reasoning progress (for LLM streaming)
-            logger_info: Info level logging callback
-            logger_warning: Warning level logging callback
-            logger_error: Error level logging callback
-        """
-        self.log_progress = log_progress or self._default_log_progress
-        self.logger_info = logger_info or self._default_logger_info
-        self.logger_warning = logger_warning or self._default_logger_warning
-        self.logger_error = logger_error or self._default_logger_error
-
-    async def _default_log_progress(self, message: str):
-        """Default progress logger - print to stdout."""
-        print(f"[RSA Progress] {message}")
-
-    async def _default_logger_info(self, message: str):
-        """Default info logger - print to stdout."""
-        print(f"[RSA Info] {message}")
-
-    async def _default_logger_warning(self, message: str):
-        """Default warning logger - print to stderr."""
-        import sys
-
-        print(f"[RSA Warning] {message}", file=sys.stderr)
-
-    async def _default_logger_error(self, message: str):
-        """Default error logger - print to stderr."""
-        import sys
-
-        print(f"[RSA Error] {message}", file=sys.stderr)
-
-
 def default_format_candidates(proposals: list[dict]) -> str:
-    """Generic formatter for RSA candidates.
+    """Format a list of proposal dicts into a prompt-ready candidates block.
 
-    Works with any Pydantic schema by extracting all fields and formatting them.
-    Domain-specific implementations can provide custom formatters.
-
-    Args:
-        proposals: List of proposal dicts with 'result' key containing validated output
-
-    Returns:
-        Formatted text suitable for aggregation prompts
+    Introspects whatever Pydantic model populates ``proposal["result"]`` so
+    that the helper works for any output schema without modification.
     """
-    candidates_text = ""
+    out = ""
     for idx, prop in enumerate(proposals, 1):
-        prop_result = prop["result"]
-        candidates_text += f"\n---- Candidate {idx} ----\n"
-
-        # Format all fields from the schema
-        for field_name, field_value in prop_result.model_dump().items():
-            # Format field name nicely (snake_case -> Title Case)
-            display_name = field_name.replace("_", " ").title()
-            candidates_text += f"{display_name}: {field_value}\n"
-
-    return candidates_text
+        out += f"\n---- Candidate {idx} ----\n"
+        for field_name, field_value in prop["result"].model_dump().items():
+            display = field_name.replace("_", " ").title()
+            out += f"{display}: {field_value}\n"
+    return out
 
 
 def create_default_proposal_task(
     user_prompt: str,
     system_prompt: Optional[str] = None,
     proposal_prompt: Optional[str] = None,
-    output_schema: Optional[type[BaseModel]] = None,
+    output_schema: Optional[Type[BaseModel]] = None,
     **task_kwargs,
-) -> Any:
-    """Create a generic proposal task using default prompts.
+) -> Task:
+    """Construct a generic proposal :class:`Task`.
 
-    This is a production-ready default that works for any problem.
-    Domain-specific implementations can provide custom task creation.
-
-    Args:
-        user_prompt: The problem/question to solve
-        system_prompt: Domain expert definition (e.g., "You are an expert chemist")
-        proposal_prompt: Task instructions for generating proposals
-        output_schema: Optional output schema (uses GenericRSAOutput if None)
-        **task_kwargs: Additional arguments passed to Task (server_urls, builtin_tools, etc.)
-
-    Returns:
-        Task instance configured for proposal generation
+    Combines ``proposal_prompt`` (instructions) with ``user_prompt`` (the
+    specific problem) and wraps the result in a Task with the supplied
+    schema. Used as the default body of :meth:`RSATask.build_proposal_task`
+    and exposed for callers that want one-off Task construction without an
+    RSA loop.
     """
-    from charge.tasks.task import Task
-
     if system_prompt is None:
-        system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
-
+        system_prompt = _DEFAULT_SYSTEM_PROMPT
     if proposal_prompt is None:
-        proposal_prompt = "Your task is to generate a high-quality solution to the problem. Use available tools and provide clear reasoning."
-
-    # Combine proposal instructions with user's problem
-    combined_user_prompt = f"{proposal_prompt}\n\n{user_prompt}"
-
+        proposal_prompt = _FALLBACK_PROPOSAL_PROMPT
     if output_schema is None:
         output_schema = GenericRSAOutput
 
-    task = Task(
+    combined = f"{proposal_prompt}\n\n{user_prompt}"
+    return Task(
         system_prompt=system_prompt,
-        user_prompt=combined_user_prompt,
+        user_prompt=combined,
         structured_output_schema=output_schema,
         **task_kwargs,
     )
-
-    return task
 
 
 def create_default_aggregation_task(
     original_user_prompt: str,
     candidates_text: str,
-    subset: list[dict],
     step: int,
     total_steps: int,
     aggregation_prompt: Optional[str] = None,
     system_prompt: Optional[str] = None,
-    output_schema: Optional[type[BaseModel]] = None,
+    output_schema: Optional[Type[BaseModel]] = None,
     **task_kwargs,
-) -> Any:
-    """Create a generic aggregation task using default template.
+) -> Task:
+    """Construct a generic aggregation :class:`Task`.
 
-    This is a production-ready default that works for any problem.
-    Domain-specific implementations can provide custom task creation.
-
-    Args:
-        original_user_prompt: The original problem/question
-        candidates_text: Formatted candidate solutions
-        subset: list of candidate proposal dicts (unused in generic version)
-        step: Current aggregation step (2..T)
-        total_steps: Total number of steps (T)
-        aggregation_prompt: Task instructions template for aggregation (uses {original_prompt},
-                           {candidates}, {step}, {total_steps} placeholders)
-        system_prompt: Domain expert definition (same as proposals)
-        output_schema: Optional output schema (uses GenericRSAOutput if None)
-        **task_kwargs: Additional arguments passed to Task
-
-    Returns:
-        Task instance configured for aggregation
+    Formats ``aggregation_prompt`` with ``{original_prompt}``,
+    ``{candidates}``, ``{step}``, ``{total_steps}`` placeholders and wraps
+    the result in a Task with the supplied schema.
     """
-    from charge.tasks.task import Task
-
     if system_prompt is None:
-        system_prompt = "You are an expert problem solver using systematic reasoning and available tools."
-
+        system_prompt = _DEFAULT_SYSTEM_PROMPT
     if aggregation_prompt is None:
-        # Load default aggregation template
-        if _DEFAULT_AGGREGATION_TEMPLATE.exists():
-            aggregation_prompt = _DEFAULT_AGGREGATION_TEMPLATE.read_text()
-        else:
-            aggregation_prompt = (
-                "Original problem:\n{original_prompt}\n\n"
-                "Candidates (Step {step} of {total_steps}):\n{candidates}\n\n"
-                "Synthesize these into a single improved solution."
-            )
-
+        aggregation_prompt = _FALLBACK_AGGREGATION_PROMPT
     if output_schema is None:
         output_schema = GenericRSAOutput
 
-    # Format the aggregation prompt
     user_prompt = aggregation_prompt.format(
         original_prompt=original_user_prompt,
         candidates=candidates_text,
         step=step,
         total_steps=total_steps,
     )
-
-    task = Task(
+    return Task(
         system_prompt=system_prompt,
         user_prompt=user_prompt,
         structured_output_schema=output_schema,
         **task_kwargs,
     )
 
-    return task
+
+# Type aliases
+_AsyncStr = Callable[[str], Awaitable[Any]]
 
 
-class RSATaskFactories(Generic[T]):
-    """Factory functions for creating RSA tasks.
+class RSATask(Task):
+    """A :class:`Task` that orchestrates the N-K-T RSA loop.
 
-    This class encapsulates task creation logic. All parameters are optional
-    with production-ready defaults, allowing RSA to work out-of-box.
-    Domain-specific implementations can override any component.
+    Domain-agnostic by construction: every hook method (``format_candidates``,
+    ``validate_proposal``, ``build_proposal_task``, ``build_aggregation_task``)
+    has a working default. Subclass to customize per-domain behavior.
+
+    Parameters
+    ----------
+    n, k, t
+        RSA hyperparameters. ``n`` is the number of initial proposals,
+        ``k`` is the aggregation subset size, ``t`` is the total number of
+        stages. All must be ``>= 2`` and ``k <= n``.
+    user_prompt
+        The specific problem to solve. Required when using the default
+        ``build_proposal_task``; subclasses that override the hook may pass
+        ``None``.
+    system_prompt
+        Domain-expert system message. Defaults to a generic problem-solver.
+    proposal_prompt
+        Instructions appended above ``user_prompt`` when building proposal
+        tasks. Defaults to a generic template loaded from the prompts/
+        directory.
+    aggregation_prompt
+        Template for aggregation tasks. Receives ``{original_prompt}``,
+        ``{candidates}``, ``{step}``, ``{total_steps}`` placeholders.
+    structured_output_schema
+        Pydantic model for parsing/validating LLM output. Defaults to
+        :class:`GenericRSAOutput`.
+    parallel
+        If True (default), runs proposals and aggregations concurrently when
+        a ``runner_factory`` is supplied to :meth:`run_rsa`. Falls back to
+        sequential execution otherwise.
+    log_dir
+        Directory to write per-stage JSON logs. Auto-generated under
+        ``/tmp/rsa_execution_<timestamp>`` when ``None``.
+    disable_validation
+        If True, skip structured-output schema validation. Also enabled when
+        the ``CHARGE_DISABLE_OUTPUT_VALIDATION=1`` environment variable is set.
+    **task_kwargs
+        Extra keyword arguments forwarded to the underlying :class:`Task`
+        (e.g. ``server_urls``, ``server_files``, ``bearer_token``,
+        ``builtin_tools``).
     """
 
     def __init__(
         self,
+        n: int,
+        k: int,
+        t: int,
+        *,
         user_prompt: Optional[str] = None,
-        create_proposal_task: Optional[Callable[[], Any]] = None,
-        create_aggregation_task: Optional[
-            Callable[[str, list[dict], int, int], Any]
-        ] = None,
-        format_candidates: Optional[Callable[[list[dict]], str]] = None,
-        output_schema: Optional[type[T]] = None,
-        validate_proposal: Optional[Callable[[Any], bool]] = None,
-        prompts: Optional[RSAPrompts] = None,
+        system_prompt: Optional[str] = None,
+        proposal_prompt: Optional[str] = None,
+        aggregation_prompt: Optional[str] = None,
+        structured_output_schema: Optional[Type[BaseModel]] = None,
+        parallel: bool = True,
+        log_dir: Optional[str] = None,
+        disable_validation: bool = False,
         **task_kwargs,
     ):
-        """Initialize task factories with optional overrides.
-
-        All parameters have sensible defaults for out-of-box usage.
-
-        Args:
-            user_prompt: The problem/question to solve (required for default factories).
-                        Not needed if providing custom factories.
-            create_proposal_task: Factory that returns a Task for generating proposals.
-                                 If None, uses create_default_proposal_task.
-            create_aggregation_task: Factory that returns a Task for aggregating proposals.
-                                    If None, uses create_default_aggregation_task.
-            format_candidates: Function to format proposals into text for aggregation.
-                              If None, uses default_format_candidates.
-            output_schema: Pydantic model class for validating task outputs.
-                          If None, uses GenericRSAOutput.
-            validate_proposal: Optional function to validate a proposal result.
-                              If None, accepts all proposals (returns True).
-            prompts: Optional RSAPrompts instance with custom prompts.
-                    If None, uses default task-agnostic prompts from ChARGe.
-            **task_kwargs: Additional arguments passed to Task instances
-                          (server_urls, builtin_tools, bearer_token, etc.)
-        """
-        self.output_schema = output_schema or GenericRSAOutput
-        self.validate_proposal = validate_proposal or self._default_validator
-        self.prompts = prompts or RSAPrompts()
-        self.task_kwargs = task_kwargs
-        self.user_prompt = user_prompt
-
-        # Use provided factories or create defaults
-        if create_proposal_task is not None:
-            self.create_proposal_task = create_proposal_task
-        else:
-            # Create default factory using user_prompt
-            if user_prompt is None:
-                raise ValueError(
-                    "user_prompt is required when using default task factories. "
-                    "Either provide user_prompt or custom create_proposal_task/create_aggregation_task."
-                )
-            self.create_proposal_task = self._create_default_proposal_factory()
-
-        if create_aggregation_task is not None:
-            self.create_aggregation_task = create_aggregation_task
-        else:
-            # Create default factory
-            if user_prompt is None:
-                raise ValueError(
-                    "user_prompt is required when using default task factories. "
-                    "Either provide user_prompt or custom create_proposal_task/create_aggregation_task."
-                )
-            self.create_aggregation_task = self._create_default_aggregation_factory()
-
-        self.format_candidates = format_candidates or default_format_candidates
-
-    def _create_default_proposal_factory(self) -> Callable[[], Any]:
-        """Create a default proposal task factory."""
-
-        def factory():
-            return create_default_proposal_task(
-                user_prompt=self.user_prompt,
-                system_prompt=self.prompts.system_prompt,
-                proposal_prompt=self.prompts.proposal_prompt,
-                output_schema=self.output_schema,
-                **self.task_kwargs,
+        if n < 2 or k < 2 or t < 2:
+            violators = [
+                name for name, val in (("N", n), ("K", k), ("T", t)) if val < 2
+            ]
+            raise ValueError(
+                f"RSA parameter(s) {', '.join(violators)} must be >= 2 "
+                f"(got N={n}, K={k}, T={t})."
+            )
+        if k > n:
+            raise ValueError(
+                f"RSA parameter K ({k}) cannot exceed N ({n}); "
+                "K is the subset size and must fit inside the proposal pool."
             )
 
-        return factory
+        sys_p = system_prompt or _DEFAULT_SYSTEM_PROMPT
+        prop_p = proposal_prompt or self._load_or_fallback(
+            _DEFAULT_PROPOSAL_SYSTEM, _FALLBACK_PROPOSAL_PROMPT
+        )
+        agg_p = aggregation_prompt or self._load_or_fallback(
+            _DEFAULT_AGGREGATION_TEMPLATE, _FALLBACK_AGGREGATION_PROMPT
+        )
+        schema = structured_output_schema or GenericRSAOutput
 
-    def _create_default_aggregation_factory(
-        self,
-    ) -> Callable[[str, list[dict], int, int], Any]:
-        """Create a default aggregation task factory."""
+        # Initialize the underlying Task: user_prompt is the problem statement
+        # so subclasses inherit access to it via self.user_prompt.
+        super().__init__(
+            system_prompt=sys_p,
+            user_prompt=user_prompt,
+            structured_output_schema=schema,
+            **task_kwargs,
+        )
 
-        def factory(
-            candidates_text: str, subset: list[dict], step: int, total_steps: int
-        ):
-            return create_default_aggregation_task(
-                original_user_prompt=self.user_prompt,
-                candidates_text=candidates_text,
-                subset=subset,
-                step=step,
-                total_steps=total_steps,
-                aggregation_prompt=self.prompts.aggregation_prompt,
-                system_prompt=self.prompts.system_prompt,  # Same expert as proposals
-                output_schema=self.output_schema,
-                **self.task_kwargs,
-            )
+        self.n = n
+        self.k = k
+        self.t = t
+        self.proposal_prompt = prop_p
+        self.aggregation_prompt = agg_p
+        self.parallel = parallel
+        self.disable_validation = disable_validation
 
-        return factory
+        if log_dir is None:
+            ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            log_dir = f"/tmp/rsa_execution_{ts}"
+        self.log_dir = log_dir
+        os.makedirs(self.log_dir, exist_ok=True)
 
-    def _default_validator(self, result: Any) -> bool:
-        """Default validator - always returns True."""
+        # Stash so default builders can reconstruct child Tasks with the same
+        # tool / server / token configuration.
+        self._task_kwargs = task_kwargs
+
+    @staticmethod
+    def _load_or_fallback(path: Path, fallback: str) -> str:
+        return path.read_text() if path.exists() else fallback
+
+    # -------- Hooks (override in subclasses for domain customization) --------
+
+    def format_candidates(self, subset: list[dict]) -> str:
+        """Format a K-subset of proposals as candidates text for aggregation."""
+        return default_format_candidates(subset)
+
+    def validate_proposal(self, result: BaseModel) -> bool:
+        """Return True if ``result`` is acceptable. Defaults to accept-all."""
         return True
 
+    def build_proposal_task(self) -> Task:
+        """Return a fresh :class:`Task` for generating one proposal.
 
-async def run_rsa_loop(
-    config: RSAConfig,
-    factories: RSATaskFactories,
-    callbacks: RSACallbacks,
-    runner: Any,
-    runner_factory: Optional[Callable[[], Any]] = None,
-    callback_handler: Optional[Any] = None,
-) -> tuple[str, Any]:
-    """
-    Execute the generic N-K-T RSA algorithm.
+        Default delegates to :func:`create_default_proposal_task` using this
+        RSATask's prompts, schema, and ``**task_kwargs``.
+        """
+        if self.user_prompt is None:
+            raise ValueError(
+                "user_prompt is required when using the default "
+                "build_proposal_task; either pass user_prompt to __init__ or "
+                "override build_proposal_task in a subclass."
+            )
+        return create_default_proposal_task(
+            user_prompt=self.user_prompt,
+            system_prompt=self.system_prompt,
+            proposal_prompt=self.proposal_prompt,
+            output_schema=self.structured_output_schema,
+            **self._task_kwargs,
+        )
 
-    Args:
-        config: RSA configuration (n, k, t, parallel, log_dir)
-        factories: Task factory functions for proposal and aggregation
-        callbacks: Logging and progress callbacks
-        runner: ChARGe agent runner with .task and .run() interface
-        runner_factory: Factory to create independent runner instances for parallel execution.
-                       If None and parallel=True, falls back to sequential execution.
-        callback_handler: Optional callback handler to drain after each task
+    def build_aggregation_task(self, candidates_text: str, step: int) -> Task:
+        """Return a fresh :class:`Task` for aggregating one K-subset.
 
-    Returns:
-        tuple: (final_output_json, final_result_object)
+        Default delegates to :func:`create_default_aggregation_task`.
+        """
+        if self.user_prompt is None:
+            raise ValueError(
+                "user_prompt is required when using the default "
+                "build_aggregation_task; either pass user_prompt to __init__ "
+                "or override build_aggregation_task in a subclass."
+            )
+        return create_default_aggregation_task(
+            original_user_prompt=self.user_prompt,
+            candidates_text=candidates_text,
+            step=step,
+            total_steps=self.t,
+            aggregation_prompt=self.aggregation_prompt,
+            system_prompt=self.system_prompt,
+            output_schema=self.structured_output_schema,
+            **self._task_kwargs,
+        )
 
-    Raises:
-        ValueError: If all proposals fail or invalid parameters
-    """
-    # K validation happens in RSAConfig.__post_init__
-    k = config.k
+    # ---------------------- The N-K-T orchestrator ----------------------
 
-    # Helper function to run a single proposal
-    async def run_single_proposal(proposal_index: int, proposal_runner: Any):
-        """Run a single proposal and return result or None if failed"""
-        try:
-            await callbacks.logger_info(
-                f"Generating proposal {proposal_index+1}/{config.n}"
+    async def run_rsa(
+        self,
+        runner: Any,
+        *,
+        runner_factory: Optional[Callable[[], Any]] = None,
+        log_progress: Optional[Callable[[str], Any]] = None,
+        logger_info: Optional[_AsyncStr] = None,
+        logger_warning: Optional[_AsyncStr] = None,
+        logger_error: Optional[_AsyncStr] = None,
+        callback_handler: Optional[Any] = None,
+    ) -> tuple[str, BaseModel]:
+        """Execute the N-K-T RSA loop.
+
+        Parameters
+        ----------
+        runner
+            ChARGe agent runner with a ``.task`` attribute and an awaitable
+            ``run(log_progress)`` method. Used directly in sequential mode and
+            as a fallback when ``runner_factory`` is omitted.
+        runner_factory
+            Factory that returns a fresh runner per parallel proposal. Required
+            for parallel execution; without it, the loop runs sequentially.
+        log_progress
+            Per-token / per-chunk streaming callback handed to ``runner.run``.
+        logger_info, logger_warning, logger_error
+            Async loggers for stage-level events. Default to loguru wrappers.
+        callback_handler
+            Optional handler with an awaitable ``drain()`` method, called after
+            each runner invocation to flush UI updates.
+
+        Returns
+        -------
+        (final_output_json, final_result)
+            ``final_output_json`` is the raw JSON string returned by the LLM
+            for the chosen final proposal; ``final_result`` is the same data
+            already validated against ``structured_output_schema``.
+
+        Raises
+        ------
+        ValueError
+            If no proposal survives Stage 1 or no aggregation survives any
+            subsequent stage.
+        """
+        info = logger_info or self._default_info
+        warning = logger_warning or self._default_warning
+        # logger_error reserved for future use; keep parameter to preserve API.
+        del logger_error
+
+        # Stage 1: N proposals
+        await info(
+            f"RSA Step 1/{self.t}: Generating {self.n} initial proposals"
+            + (" (parallel mode)" if self.parallel else " (sequential mode)")
+        )
+        proposals = await self._stage_proposals(
+            runner, runner_factory, log_progress, info, warning, callback_handler
+        )
+        if not proposals:
+            raise ValueError("All RSA proposals failed")
+        await info(
+            f"Stage 1 complete. Generated {len(proposals)} valid proposals."
+        )
+
+        # Stages 2..T: recursive aggregation
+        current = proposals
+        step = 1  # defensive default; range below always assigns at least once
+        for step in range(2, self.t + 1):
+            await info(
+                f"RSA Step {step}/{self.t}: Aggregating {len(current)} "
+                f"proposals into {self.k}-subsets"
+                + (" (parallel mode)" if self.parallel else " (sequential mode)")
+            )
+            if len(current) < self.k:
+                await warning(
+                    f"Step {step}: only {len(current)} proposals available; "
+                    f"K reduced from {self.k} to {len(current)} for this stage."
+                )
+
+            num_aggs = max(self.n, len(current))
+            next_props = await self._stage_aggregations(
+                num_aggs, step, current, runner, runner_factory,
+                log_progress, info, warning, callback_handler,
+            )
+            if not next_props:
+                await warning(
+                    f"No successful aggregations in step {step}; "
+                    "falling back to previous stage's proposals."
+                )
+                break
+            current = next_props
+            await info(
+                f"Stage {step} complete. Generated {len(current)} valid aggregations."
             )
 
-            # Create proposal task
-            proposal_task = factories.create_proposal_task()
-            proposal_runner.task = proposal_task
+        if not current:
+            raise ValueError("RSA failed to produce any valid proposals")
 
-            # Disable validation if requested
-            if (
-                config.disable_validation
-                or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1"
-            ):
-                proposal_task.structured_output_schema = None
+        final = current[0]
+        final_output = final["output"]
+        final_result = final["result"]
 
-            # Save proposal prompt
-            proposer_log = {
-                "proposal_index": proposal_index + 1,
-                "system_prompt": proposal_task.get_system_prompt(),
-                "user_prompt": proposal_task.get_user_prompt(),
-            }
-            with open(
-                f"{config.log_dir}/proposer_{proposal_index+1:02d}_prompt.json", "w"
-            ) as f:
-                json.dump(proposer_log, f, indent=2)
+        log_path = Path(self.log_dir) / "FINAL_OUTPUT.json"
+        log_path.write_text(
+            json.dumps(
+                {
+                    "final_step": step if step <= self.t else self.t,
+                    "n_proposals": self.n,
+                    "k_subset_size": self.k,
+                    "t_stages": self.t,
+                    "final_result": final_result.model_dump(),
+                },
+                indent=2,
+            )
+        )
+        await info(f"RSA completed! Final output saved to {self.log_dir}")
 
-            # Run proposal
-            proposal_output = await proposal_runner.run(callbacks.log_progress)
+        return final_output, final_result
+
+    # ----------------------- private orchestration -------------------------
+
+    def _validation_disabled(self) -> bool:
+        return (
+            self.disable_validation
+            or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1"
+        )
+
+    def _write_json(self, name: str, payload: dict) -> None:
+        with open(f"{self.log_dir}/{name}", "w") as f:
+            json.dump(payload, f, indent=2)
+
+    async def _run_single_proposal(
+        self,
+        index: int,
+        runner: Any,
+        log_progress: Optional[Callable],
+        info: _AsyncStr,
+        warning: _AsyncStr,
+        callback_handler: Optional[Any],
+    ) -> Optional[dict]:
+        try:
+            await info(f"Generating proposal {index + 1}/{self.n}")
+            task = self.build_proposal_task()
+            runner.task = task
+            if self._validation_disabled():
+                task.structured_output_schema = None
+
+            self._write_json(
+                f"proposer_{index + 1:02d}_prompt.json",
+                {
+                    "proposal_index": index + 1,
+                    "system_prompt": task.get_system_prompt(),
+                    "user_prompt": task.get_user_prompt(),
+                },
+            )
+
+            output = await runner.run(log_progress)
             if callback_handler:
                 await callback_handler.drain()
 
-            # Validate output
-            proposal_result = factories.output_schema.model_validate_json(
-                proposal_output
-            )
+            schema = self.structured_output_schema or GenericRSAOutput
+            result = schema.model_validate_json(output)
 
-            # Check if proposal is valid using custom validator
-            if not factories.validate_proposal(proposal_result):
-                await callbacks.logger_warning(
-                    f"Proposal {proposal_index+1} failed validation (empty or invalid), skipping"
+            if not self.validate_proposal(result):
+                await warning(
+                    f"Proposal {index + 1} failed validation (empty or invalid), skipping"
                 )
                 return None
 
-            # Save proposal output
-            proposer_output_log = {
-                "proposal_index": proposal_index + 1,
-                "result": proposal_result.model_dump(),
-                "full_output": json.loads(proposal_output),
-            }
-            with open(
-                f"{config.log_dir}/proposer_{proposal_index+1:02d}_output.json", "w"
-            ) as f:
-                json.dump(proposer_output_log, f, indent=2)
-
-            await callbacks.logger_info(
-                f"Proposal {proposal_index+1} completed successfully"
+            self._write_json(
+                f"proposer_{index + 1:02d}_output.json",
+                {
+                    "proposal_index": index + 1,
+                    "result": result.model_dump(),
+                    "full_output": json.loads(output),
+                },
             )
-
-            return {
-                "output": proposal_output,
-                "result": proposal_result,
-                "index": proposal_index,
-            }
+            await info(f"Proposal {index + 1} completed successfully")
+            return {"output": output, "result": result, "index": index}
 
         except asyncio.CancelledError:
-            await callbacks.logger_warning(f"Proposal {proposal_index+1} was cancelled")
+            await warning(f"Proposal {index + 1} was cancelled")
             return None
         except Exception as e:
-            await callbacks.logger_warning(
-                f"Proposal {proposal_index+1} failed: {str(e)}"
-            )
+            await warning(f"Proposal {index + 1} failed: {str(e)}")
             return None
 
-    # Stage 1: Generate N initial proposals
-    await callbacks.logger_info(
-        f"RSA Step 1/{config.t}: Generating {config.n} initial proposals"
-        + (" (parallel mode)" if config.parallel else " (sequential mode)")
-    )
-
-    if config.parallel and runner_factory:
-        # Parallel mode: generate all proposals concurrently
-        proposal_tasks = []
-        for i in range(config.n):
-            # Create independent runner for each proposal
-            proposal_runner = runner_factory()
-            task = run_single_proposal(i, proposal_runner)
-            proposal_tasks.append(task)
-
-        # Run all proposals in parallel
-        proposal_results = await asyncio.gather(*proposal_tasks, return_exceptions=True)
-
-        # Filter valid proposals and handle exceptions
-        proposals = []
-        for i, result in enumerate(proposal_results):
-            if isinstance(result, Exception):
-                await callbacks.logger_warning(
-                    f"Proposal {i+1} failed with exception: {str(result)}"
-                )
-            elif result is not None:
-                proposals.append(result)
-    else:
-        # Sequential mode: generate proposals one by one
-        if config.parallel and not runner_factory:
-            await callbacks.logger_warning(
-                "Parallel mode requested but no runner_factory provided, falling back to sequential"
-            )
-
-        proposals = []
-        for i in range(config.n):
-            result = await run_single_proposal(i, runner)
-            if result is not None:
-                proposals.append(result)
-
-    if not proposals:
-        raise ValueError("All RSA proposals failed")
-
-    await callbacks.logger_info(f"Generated {len(proposals)} valid proposals")
-
-    # Helper function to run a single aggregation
-    async def run_single_aggregation(
-        agg_index: int, step: int, current_proposals: list, agg_runner: Any
-    ):
-        """Run a single aggregation and return result or None if failed"""
+    async def _run_single_aggregation(
+        self,
+        agg_index: int,
+        step: int,
+        current_proposals: list[dict],
+        runner: Any,
+        log_progress: Optional[Callable],
+        info: _AsyncStr,
+        warning: _AsyncStr,
+        callback_handler: Optional[Any],
+    ) -> Optional[dict]:
         try:
-            # Adjust K if needed
-            current_k = k
-            if len(current_proposals) < k:
-                current_k = len(current_proposals)
-
-            # Select K random proposals
+            current_k = min(self.k, len(current_proposals))
             if len(current_proposals) <= current_k:
                 subset = current_proposals
             else:
                 subset = random.sample(current_proposals, current_k)
 
-            # Format candidates using task-specific formatter
-            candidates_text = factories.format_candidates(subset)
-            subset_indices = [prop["index"] + 1 for prop in subset]
+            candidates_text = self.format_candidates(subset)
+            subset_indices = [p["index"] + 1 for p in subset]
 
-            # Create aggregation task
-            agg_task = factories.create_aggregation_task(
-                candidates_text, subset, step, config.t
-            )
-            agg_runner.task = agg_task
-
-            if (
-                config.disable_validation
-                or os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1"
-            ):
+            agg_task = self.build_aggregation_task(candidates_text, step)
+            runner.task = agg_task
+            if self._validation_disabled():
                 agg_task.structured_output_schema = None
 
-            # Save aggregation prompt
-            aggregator_log = {
-                "step": step,
-                "aggregation_index": agg_index + 1,
-                "k_subset_indices": subset_indices,
-                "system_prompt": agg_task.get_system_prompt(),
-                "user_prompt": agg_task.get_user_prompt(),
-                "candidates_text": candidates_text,
-            }
-            with open(
-                f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_prompt.json",
-                "w",
-            ) as f:
-                json.dump(aggregator_log, f, indent=2)
+            self._write_json(
+                f"aggregator_step{step}_{agg_index + 1:02d}_prompt.json",
+                {
+                    "step": step,
+                    "aggregation_index": agg_index + 1,
+                    "k_subset_indices": subset_indices,
+                    "system_prompt": agg_task.get_system_prompt(),
+                    "user_prompt": agg_task.get_user_prompt(),
+                    "candidates_text": candidates_text,
+                },
+            )
 
-            # Run aggregation
-            agg_output = await agg_runner.run(callbacks.log_progress)
+            output = await runner.run(log_progress)
             if callback_handler:
                 await callback_handler.drain()
 
-            # Validate output
-            agg_result = factories.output_schema.model_validate_json(agg_output)
+            schema = self.structured_output_schema or GenericRSAOutput
+            result = schema.model_validate_json(output)
 
-            # Check if aggregation is valid using custom validator
-            if not factories.validate_proposal(agg_result):
-                await callbacks.logger_warning(
-                    f"Aggregation {agg_index+1} (Step {step}) failed validation (empty or invalid), skipping"
+            if not self.validate_proposal(result):
+                await warning(
+                    f"Aggregation {agg_index + 1} (Step {step}) failed validation, skipping"
                 )
                 return None
 
-            # Save aggregation output
-            aggregator_output_log = {
-                "step": step,
-                "aggregation_index": agg_index + 1,
-                "k_subset_indices": subset_indices,
-                "result": agg_result.model_dump(),
-                "full_output": json.loads(agg_output),
-            }
-            with open(
-                f"{config.log_dir}/aggregator_step{step}_{agg_index+1:02d}_output.json",
-                "w",
-            ) as f:
-                json.dump(aggregator_output_log, f, indent=2)
-
-            await callbacks.logger_info(
-                f"Aggregation {agg_index+1} (Step {step}) completed successfully"
+            self._write_json(
+                f"aggregator_step{step}_{agg_index + 1:02d}_output.json",
+                {
+                    "step": step,
+                    "aggregation_index": agg_index + 1,
+                    "k_subset_indices": subset_indices,
+                    "result": result.model_dump(),
+                    "full_output": json.loads(output),
+                },
             )
-
+            await info(
+                f"Aggregation {agg_index + 1} (Step {step}) completed successfully"
+            )
             return {
-                "output": agg_output,
-                "result": agg_result,
+                "output": output,
+                "result": result,
                 "index": agg_index,
                 "step": step,
             }
 
         except asyncio.CancelledError:
-            await callbacks.logger_warning(
-                f"Aggregation {agg_index+1} (Step {step}) was cancelled"
-            )
+            await warning(f"Aggregation {agg_index + 1} (Step {step}) was cancelled")
             return None
         except Exception as e:
-            await callbacks.logger_warning(
-                f"Aggregation {agg_index+1} (Step {step}) failed: {str(e)}"
+            await warning(
+                f"Aggregation {agg_index + 1} (Step {step}) failed: {str(e)}"
             )
             return None
 
-    # Stages 2-T: Recursive aggregation
-    # BARRIER: Wait for all Stage 1 proposals to complete before starting Stage 2
-    current_proposals = proposals
-    await callbacks.logger_info(
-        f"Stage 1 complete. Generated {len(proposals)} valid proposals."
-    )
+    async def _stage_proposals(
+        self,
+        runner: Any,
+        runner_factory: Optional[Callable[[], Any]],
+        log_progress: Optional[Callable],
+        info: _AsyncStr,
+        warning: _AsyncStr,
+        callback_handler: Optional[Any],
+    ) -> list[dict]:
+        if self.parallel and runner_factory:
+            coros = [
+                self._run_single_proposal(
+                    i, runner_factory(), log_progress, info, warning, callback_handler
+                )
+                for i in range(self.n)
+            ]
+            results = await asyncio.gather(*coros, return_exceptions=True)
+            out: list[dict] = []
+            for i, r in enumerate(results):
+                if isinstance(r, Exception):
+                    await warning(f"Proposal {i + 1} failed with exception: {str(r)}")
+                elif r is not None:
+                    out.append(r)
+            return out
 
-    for step in range(2, config.t + 1):
-        await callbacks.logger_info(
-            f"RSA Step {step}/{config.t}: Aggregating {len(current_proposals)} proposals into {k}-subsets"
-            + (" (parallel mode)" if config.parallel else " (sequential mode)")
-        )
-
-        # Log if K needs adjustment due to insufficient proposals
-        if len(current_proposals) < k:
-            await callbacks.logger_warning(
-                f"Step {step}: Only {len(current_proposals)} proposals available, K will be adjusted from {k} to {len(current_proposals)} for this stage"
+        if self.parallel and not runner_factory:
+            await warning(
+                "Parallel mode requested but no runner_factory provided; "
+                "falling back to sequential."
             )
+        out: list[dict] = []
+        for i in range(self.n):
+            r = await self._run_single_proposal(
+                i, runner, log_progress, info, warning, callback_handler
+            )
+            if r is not None:
+                out.append(r)
+        return out
 
-        # Generate aggregations
-        num_aggregations = max(config.n, len(current_proposals))
-
-        if config.parallel and runner_factory:
-            # Parallel mode: run all aggregations in this stage concurrently
-            agg_tasks = []
-            for i in range(num_aggregations):
-                # Create independent runner for each aggregation
-                agg_runner = runner_factory()
-                task = run_single_aggregation(i, step, current_proposals, agg_runner)
-                agg_tasks.append(task)
-
-            # Run all aggregations in parallel and wait for all to complete
-            # BARRIER: asyncio.gather waits for all aggregations in this stage
-            agg_results = await asyncio.gather(*agg_tasks, return_exceptions=True)
-
-            # Filter valid aggregations and handle exceptions
-            next_proposals = []
-            for i, result in enumerate(agg_results):
-                if isinstance(result, Exception):
-                    await callbacks.logger_warning(
-                        f"Aggregation {i+1} (Step {step}) failed with exception: {str(result)}"
+    async def _stage_aggregations(
+        self,
+        num_aggs: int,
+        step: int,
+        current: list[dict],
+        runner: Any,
+        runner_factory: Optional[Callable[[], Any]],
+        log_progress: Optional[Callable],
+        info: _AsyncStr,
+        warning: _AsyncStr,
+        callback_handler: Optional[Any],
+    ) -> list[dict]:
+        if self.parallel and runner_factory:
+            coros = [
+                self._run_single_aggregation(
+                    i, step, current, runner_factory(),
+                    log_progress, info, warning, callback_handler,
+                )
+                for i in range(num_aggs)
+            ]
+            results = await asyncio.gather(*coros, return_exceptions=True)
+            out: list[dict] = []
+            for i, r in enumerate(results):
+                if isinstance(r, Exception):
+                    await warning(
+                        f"Aggregation {i + 1} (Step {step}) failed with exception: {str(r)}"
                     )
-                elif result is not None:
-                    next_proposals.append(result)
+                elif r is not None:
+                    out.append(r)
+            return out
 
-        else:
-            # Sequential mode: run aggregations one by one
-            if config.parallel and not runner_factory:
-                await callbacks.logger_warning(
-                    "Parallel mode requested but no runner_factory provided, falling back to sequential"
-                )
-
-            next_proposals = []
-            for i in range(num_aggregations):
-                result = await run_single_aggregation(
-                    i, step, current_proposals, runner
-                )
-                if result is not None:
-                    next_proposals.append(result)
-
-        if not next_proposals:
-            await callbacks.logger_warning(
-                f"No successful aggregations in step {step}, using previous proposals"
+        if self.parallel and not runner_factory:
+            await warning(
+                "Parallel mode requested but no runner_factory provided; "
+                "falling back to sequential."
             )
-            break
+        out: list[dict] = []
+        for i in range(num_aggs):
+            r = await self._run_single_aggregation(
+                i, step, current, runner,
+                log_progress, info, warning, callback_handler,
+            )
+            if r is not None:
+                out.append(r)
+        return out
 
-        # BARRIER: All aggregations in current stage complete before moving to next stage
-        current_proposals = next_proposals
-        await callbacks.logger_info(
-            f"Stage {step} complete. Generated {len(current_proposals)} valid aggregations."
-        )
+    # ------------------- default loggers (stdout/stderr) --------------------
 
-    # Select final proposal (first one from final stage)
-    if not current_proposals:
-        raise ValueError("RSA failed to produce any valid proposals")
+    async def _default_info(self, message: str) -> None:
+        print(f"[RSA Info] {message}")
 
-    final_proposal = current_proposals[0]
-    final_output = final_proposal["output"]
-    final_result = final_proposal["result"]
+    async def _default_warning(self, message: str) -> None:
+        print(f"[RSA Warning] {message}", file=sys.stderr)
 
-    # Save final output
-    final_log = {
-        "final_step": step if step <= config.t else config.t,
-        "n_proposals": config.n,
-        "k_subset_size": k,
-        "t_stages": config.t,
-        "final_result": final_result.model_dump(),
-    }
-    log_path = Path(config.log_dir) / "FINAL_OUTPUT.json"
-    log_path.write_text(json.dumps(final_log, indent=2))
-
-    await callbacks.logger_info(
-        f"RSA completed! Final output saved to {config.log_dir}"
-    )
-
-    return final_output, final_result
+    async def _default_error(self, message: str) -> None:
+        print(f"[RSA Error] {message}", file=sys.stderr)

--- a/charge/algorithms/rsa.py
+++ b/charge/algorithms/rsa.py
@@ -1,6 +1,6 @@
 """
 Recursive Self-Aggregation (RSA) Algorithm
-
+https://arxiv.org/pdf/2509.26626
 This module provides the core N-K-T RSA loop that can be used by any task type
 (retrosynthesis, LMO, etc.) through customizable factory functions and formatters.
 

--- a/charge/tasks/task.py
+++ b/charge/tasks/task.py
@@ -102,6 +102,20 @@ class Task(ABC):
 
         self.constructor_args = {}
 
+    async def run(self, agent, *args, **kwargs):
+        """Run this Task on the given Agent.
+
+        Default behavior: assign ``self`` to ``agent.task`` and dispatch to
+        ``agent.run``. Agents read prompts and schemas off their ``.task``
+        attribute (see the Agent ABC), so this hands the Task to the Agent
+        rather than passing prompts as kwargs.
+
+        Subclasses with non-trivial control flow (e.g. ``RSATask`` running an
+        N-K-T loop) override this method.
+        """
+        agent.task = self
+        return await agent.run(*args, **kwargs)
+
     def get_system_prompt(self) -> str:
         return self.system_prompt or ""
 


### PR DESCRIPTION
Add generic Recursive Self-Aggregation (RSA) algorithm as a `Task` subclass. Domain-agnostic by default; subclass to customize
  for any prompt-and-aggregate problem.

  ## Changes
  - Add `charge/algorithms/rsa.py` with `RSATask(Task)` exposing the N-K-T loop via an async `run_rsa()` method
  - Hook methods on `RSATask` for domain customization (defaults work without subclassing):
    - `format_candidates(subset)` : how candidates are rendered for aggregation
    - `validate_proposal(result)` : accept/reject a proposal
    - `build_proposal_task()` / `build_aggregation_task(text, step)` — per-stage Task construction
  - 3-part prompt structure carried on `RSATask`:
    - `system_prompt`: domain expert (proposals and aggregations)
    - `proposal_prompt`: instructions for generating a single solution
    - `aggregation_prompt`: template for synthesizing K-subsets (`{original_prompt}`, `{candidates}`, `{step}`, `{total_steps}`)
  - Module-level helpers exported for one-off Task construction without the loop:
    - `create_default_proposal_task(...)`, `create_default_aggregation_task(...)`, `default_format_candidates(...)`,
  `GenericRSAOutput`
  - Default prompts in `charge/algorithms/prompts/` (proposal system, aggregation template)
  - README rewritten with a minimal example + cross-domain example (non-retrosynthesis) demonstrating that no subclassing is
  required

  ## API
  ```python
  task = RSATask(n=4, k=2, t=2, user_prompt="...")
  output, result = await task.run_rsa(runner, runner_factory=...)

  Subclass for domain customization:
  class MyDomainRSATask(RSATask):
      def format_candidates(self, subset): ...
      def validate_proposal(self, result): ...
  ```

  Testing

  - N/K/T validation rejects values < 2 and K > N with messages naming the violator(s)
  - Default hooks introspect any Pydantic schema (verified with GenericRSAOutput and a custom schema)
  - Bearer token / server_urls / builtin_tools correctly propagated to every per-proposal and per-aggregation Task

  Related PRs

  - FLASK-LLNL/flask-copilot#194 : consumes RSATask via RetroRSATask subclass
  - FLASK-LLNL/LC-Conductor#15 : provides the RSA settings UI panel