### PR TITLE
Agent registry and session serialization

### DIFF
--- a/charge/clients/agent_factory.py
+++ b/charge/clients/agent_factory.py
@@ -4,20 +4,25 @@ from abc import abstractmethod
 from dataclasses import dataclass
 import json
 import warnings
-from typing import Any, Awaitable, Callable, Literal, Optional, Protocol, TypeAlias
+from typing import Any, Literal, Optional, Protocol, TypeAlias
 
 DEFAULT_BACKEND = "agentframework"
 """
 Default backend to use for agent factory
 """
 
-ReasoningCallbackType: TypeAlias = Optional[Callable[[str], Awaitable[None]]]
-
 
 class AgentCallback(Protocol):
     async def on_task_start(self) -> None: ...
 
     async def on_task_finish(self) -> None: ...
+
+    async def on_reasoning_update(
+        self,
+        text: str,
+        *,
+        source: Optional[str] = None,
+    ) -> None: ...
 
     async def on_tool_call(
         self,
@@ -168,7 +173,7 @@ class Agent:
             await self.callback.on_task_finish()
 
     @abstractmethod
-    def run(self, reasoning_callback: ReasoningCallbackType = None, **kwargs) -> Any:
+    def run(self, **kwargs) -> Any:
         """
         Abstract method to run the Agent's task.
         """

--- a/charge/clients/agent_factory.py
+++ b/charge/clients/agent_factory.py
@@ -37,6 +37,30 @@ class AgentCallback(Protocol):
 AgentCallbackType: TypeAlias = Optional[AgentCallback]
 
 
+@dataclass(frozen=True)
+class AgentInstructionSnapshot:
+    message_count: int
+    instructions: str
+
+    @classmethod
+    def from_json(cls, record: dict[str, Any]) -> "AgentInstructionSnapshot":
+        message_count = record["messageCount"]
+        instructions = record["instructions"]
+        if not isinstance(message_count, int):
+            raise TypeError("instructionHistory messageCount must be an integer")
+        if not isinstance(instructions, str) or not instructions:
+            raise TypeError(
+                "instructionHistory instructions must be a non-empty string"
+            )
+        return cls(message_count=message_count, instructions=instructions)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "messageCount": self.message_count,
+            "instructions": self.instructions,
+        }
+
+
 class Agent:
     """
     Base class for an Agent that performs Tasks.
@@ -44,6 +68,7 @@ class Agent:
 
     task: Optional[Task]
     callback: AgentCallbackType
+    instruction_history: list[AgentInstructionSnapshot]
 
     def __init__(
         self,
@@ -55,6 +80,7 @@ class Agent:
         self.task = task
         self.callback: AgentCallbackType = callback
         self.kwargs = kwargs
+        self.instruction_history = []
 
     @abstractmethod
     def run(self, reasoning_callback: ReasoningCallbackType = None, **kwargs) -> Any:
@@ -135,7 +161,10 @@ class AgentFactory:
         """
         Abstract method to create and return an Agent instance.
         """
-        return cls.backends[backend.lower()].create_agent(
+        backend_key = backend.lower()
+        if backend_key not in cls.backends:
+            raise TypeError(f"AgentFactory does not accept backend {backend!r}")
+        return cls.backends[backend_key].create_agent(
             task, agent_key=agent_key, memory=memory, callback=callback, **kwargs
         )
 
@@ -160,26 +189,22 @@ class AgentFactory:
 
 @dataclass
 class AgentRuntimeConfig:
-    agent_key: str
     backend: str = DEFAULT_BACKEND
     model: Optional[str] = None
 
     @classmethod
-    def from_agent(cls, *, agent_key: str, agent: Agent) -> "AgentRuntimeConfig":
+    def from_agent(cls, *, agent: Agent) -> "AgentRuntimeConfig":
         model_info = agent.get_model_info()
         backend = model_info.get("backend") if isinstance(model_info, dict) else None
         model = model_info.get("model") if isinstance(model_info, dict) else None
         backend_obj = AgentFactory.default_backend()
         return cls(
-            agent_key=agent_key,
             backend=str(backend or backend_obj.backend),
             model=model or backend_obj.model,
         )
 
     @classmethod
-    def from_record(
-        cls, agent_key: str, record: dict[str, Any]
-    ) -> "AgentRuntimeConfig":
+    def from_record(cls, record: dict[str, Any]) -> "AgentRuntimeConfig":
         runtime_config = record.get("runtimeConfig")
         if not isinstance(runtime_config, dict):
             runtime_config = {}
@@ -192,14 +217,12 @@ class AgentRuntimeConfig:
             or DEFAULT_BACKEND
         )
         return cls(
-            agent_key=agent_key,
             backend=backend,
             model=runtime_config.get("model") or model_info.get("model"),
         )
 
     def to_json(self) -> dict[str, Any]:
         return {
-            "agentKey": self.agent_key,
             "backend": self.backend,
             "model": self.model,
         }
@@ -208,6 +231,7 @@ class AgentRuntimeConfig:
 def create_agent_for_runtime_config(
     *,
     task: Optional[Task],
+    agent_key: str,
     memory: Optional[Memory],
     runtime_config: AgentRuntimeConfig,
     create_kwargs: Optional[dict[str, Any]] = None,
@@ -216,23 +240,22 @@ def create_agent_for_runtime_config(
     agent = AgentFactory.create_agent(
         task=task,
         memory=memory,
-        agent_key=runtime_config.agent_key,
+        agent_key=agent_key,
         callback=callback,
         **(create_kwargs or {}),
     )
-    return agent, AgentRuntimeConfig.from_agent(
-        agent_key=runtime_config.agent_key,
-        agent=agent,
-    )
+    return agent, AgentRuntimeConfig.from_agent(agent=agent)
 
 
 def verify_restored_agent_config(
-    saved_config: AgentRuntimeConfig, current_config: AgentRuntimeConfig
+    agent_key: str,
+    saved_config: AgentRuntimeConfig,
+    current_config: AgentRuntimeConfig,
 ) -> None:
     if saved_config.backend != current_config.backend:
         raise RuntimeError(
             "Cannot restore agent session with mismatched backend for "
-            f"{saved_config.agent_key!r}: saved {saved_config.backend!r}, "
+            f"{agent_key!r}: saved {saved_config.backend!r}, "
             f"current {current_config.backend!r}."
         )
     if (
@@ -242,7 +265,7 @@ def verify_restored_agent_config(
     ):
         warnings.warn(
             "Restoring agent session with a different model for "
-            f"{saved_config.agent_key!r}: saved {saved_config.model!r}, "
+            f"{agent_key!r}: saved {saved_config.model!r}, "
             f"current {current_config.model!r}.",
             RuntimeWarning,
             stacklevel=2,
@@ -250,19 +273,24 @@ def verify_restored_agent_config(
 
 
 def serialize_agent_session(
-    agent_key: str, agent: Agent, runtime_config: AgentRuntimeConfig
+    agent: Agent,
+    runtime_config: AgentRuntimeConfig,
 ) -> dict[str, Any]:
     task_json = None
     task = agent.task
     if task is not None:
         task_json = task.to_json()
-    return {
-        "agentKey": agent_key,
+    record = {
         "runtimeConfig": runtime_config.to_json(),
         "memory": agent.save_memory(),
         "modelInfo": agent.get_model_info(),
         "task": task_json,
     }
+    if agent.instruction_history:
+        record["instructionHistory"] = [
+            snapshot.to_json() for snapshot in agent.instruction_history
+        ]
+    return record
 
 
 def restore_agent_session(
@@ -284,13 +312,14 @@ def restore_agent_session(
                 stacklevel=2,
             )
 
-    saved_config = AgentRuntimeConfig.from_record(agent_key, record)
+    saved_config = AgentRuntimeConfig.from_record(record)
     agent, current_config = create_agent_for_runtime_config(
         task=task,
+        agent_key=agent_key,
         memory=memory,
         runtime_config=saved_config,
     )
-    verify_restored_agent_config(saved_config, current_config)
+    verify_restored_agent_config(agent_key, saved_config, current_config)
 
     memory_json = record.get("memory")
     if memory_json:
@@ -304,4 +333,11 @@ def restore_agent_session(
                 RuntimeWarning,
                 stacklevel=2,
             )
+    instruction_history = record.get("instructionHistory")
+    if isinstance(instruction_history, list):
+        agent.instruction_history = [
+            AgentInstructionSnapshot.from_json(snapshot)
+            for snapshot in instruction_history
+            if isinstance(snapshot, dict)
+        ]
     return agent, current_config

--- a/charge/clients/agent_factory.py
+++ b/charge/clients/agent_factory.py
@@ -2,6 +2,7 @@ from charge.tasks.task import Task
 from charge.experiments.memory import Memory
 from abc import abstractmethod
 from dataclasses import dataclass
+import json
 import warnings
 from typing import Any, Awaitable, Callable, Literal, Optional, Protocol, TypeAlias
 
@@ -81,6 +82,84 @@ class Agent:
         self.callback: AgentCallbackType = callback
         self.kwargs = kwargs
         self.instruction_history = []
+        self.pending_user_message: Optional[dict[str, Any]] = None
+
+    def _message_count(self) -> int:
+        try:
+            memory = json.loads(self.save_memory() or "{}")
+        except (TypeError, ValueError):
+            return 0
+        if not isinstance(memory, dict):
+            return 0
+        state = memory.get("state")
+        if not isinstance(state, dict):
+            return 0
+        in_memory = state.get("in_memory")
+        if not isinstance(in_memory, dict):
+            return 0
+        messages = in_memory.get("messages")
+        return len(messages) if isinstance(messages, list) else 0
+
+    def begin_task_run(self) -> None:
+        if self.task is None:
+            self.pending_user_message = None
+            return
+        text = self.task.get_user_prompt().strip()
+        if not text:
+            self.pending_user_message = None
+            return
+        pending: dict[str, Any] = {
+            "text": text,
+            "afterMessageCount": self._message_count(),
+        }
+        attachments = getattr(self.task, "attachments", []) or []
+        images = []
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            images.append(
+                {
+                    "id": str(attachment.get("id") or f"image_{len(images) + 1}"),
+                    "name": str(attachment.get("name") or f"Image {len(images) + 1}"),
+                    "mimeType": str(attachment.get("mimeType") or ""),
+                    "sizeBytes": int(attachment.get("sizeBytes") or 0),
+                    "dataUrl": attachment.get("dataUrl"),
+                }
+            )
+        if images:
+            pending["images"] = images
+        self.pending_user_message = pending
+
+    def finish_task_run(self) -> None:
+        self._capture_instruction_snapshot()
+        self.pending_user_message = None
+
+    def _capture_instruction_snapshot(self) -> None:
+        if self.task is None:
+            return
+        instructions = self.task.get_system_prompt().strip()
+        if not instructions:
+            return
+        message_count = self._message_count()
+        if message_count <= 0:
+            return
+        snapshot = AgentInstructionSnapshot(
+            message_count=message_count,
+            instructions=instructions,
+        )
+        if (
+            self.instruction_history
+            and self.instruction_history[-1].message_count == message_count
+        ):
+            self.instruction_history[-1] = snapshot
+        else:
+            self.instruction_history.append(snapshot)
+
+    async def notify_task_start(self) -> None:
+        callback = self.callback
+        on_task_start = getattr(callback, "on_task_start", None)
+        if on_task_start is not None:
+            await on_task_start()
 
     @abstractmethod
     def run(self, reasoning_callback: ReasoningCallbackType = None, **kwargs) -> Any:
@@ -290,6 +369,8 @@ def serialize_agent_session(
         record["instructionHistory"] = [
             snapshot.to_json() for snapshot in agent.instruction_history
         ]
+    if agent.pending_user_message:
+        record["pendingUserMessage"] = agent.pending_user_message
     return record
 
 

--- a/charge/clients/agent_factory.py
+++ b/charge/clients/agent_factory.py
@@ -15,6 +15,10 @@ ReasoningCallbackType: TypeAlias = Optional[Callable[[str], Awaitable[None]]]
 
 
 class AgentCallback(Protocol):
+    async def on_task_start(self) -> None: ...
+
+    async def on_task_finish(self) -> None: ...
+
     async def on_tool_call(
         self,
         tool_name: str,
@@ -156,10 +160,12 @@ class Agent:
             self.instruction_history.append(snapshot)
 
     async def notify_task_start(self) -> None:
-        callback = self.callback
-        on_task_start = getattr(callback, "on_task_start", None)
-        if on_task_start is not None:
-            await on_task_start()
+        if self.callback is not None:
+            await self.callback.on_task_start()
+
+    async def notify_task_finish(self) -> None:
+        if self.callback is not None:
+            await self.callback.on_task_finish()
 
     @abstractmethod
     def run(self, reasoning_callback: ReasoningCallbackType = None, **kwargs) -> Any:

--- a/charge/clients/agent_factory.py
+++ b/charge/clients/agent_factory.py
@@ -1,7 +1,9 @@
 from charge.tasks.task import Task
 from charge.experiments.memory import Memory
 from abc import abstractmethod
-from typing import Any, Awaitable, Callable, Literal, Optional, TypeAlias
+from dataclasses import dataclass
+import warnings
+from typing import Any, Awaitable, Callable, Literal, Optional, Protocol, TypeAlias
 
 DEFAULT_BACKEND = "agentframework"
 """
@@ -11,15 +13,48 @@ Default backend to use for agent factory
 ReasoningCallbackType: TypeAlias = Optional[Callable[[str], Awaitable[None]]]
 
 
+class AgentCallback(Protocol):
+    async def on_tool_call(
+        self,
+        tool_name: str,
+        arguments: Any,
+        *,
+        source: Optional[str] = None,
+        call_id: Optional[str] = None,
+    ) -> None: ...
+
+    async def on_tool_result(
+        self,
+        tool_name: str,
+        result: Any,
+        *,
+        is_error: bool = False,
+        source: Optional[str] = None,
+        call_id: Optional[str] = None,
+    ) -> None: ...
+
+
+AgentCallbackType: TypeAlias = Optional[AgentCallback]
+
+
 class Agent:
     """
     Base class for an Agent that performs Tasks.
     """
 
-    def __init__(self, task: Optional[Task], **kwargs):
+    task: Optional[Task]
+    callback: AgentCallbackType
+
+    def __init__(
+        self,
+        task: Optional[Task],
+        *,
+        callback: AgentCallbackType = None,
+        **kwargs,
+    ):
         self.task = task
+        self.callback: AgentCallbackType = callback
         self.kwargs = kwargs
-        self.context_history = []
 
     @abstractmethod
     def run(self, reasoning_callback: ReasoningCallbackType = None, **kwargs) -> Any:
@@ -29,11 +64,24 @@ class Agent:
         raise NotImplementedError("Method 'run' is not implemented.")
 
     @abstractmethod
-    def get_context_history(self) -> list:
+    def load_memory(self, json_str: str) -> None:
         """
-        Abstract method to get the Agent's context history.
+        Abstract method to load the Agent's serialized memory.
         """
-        raise NotImplementedError("Method 'get_context_history' is not implemented.")
+        raise NotImplementedError("Method 'load_memory' is not implemented.")
+
+    @abstractmethod
+    def save_memory(self) -> str:
+        """
+        Abstract method to serialize the Agent's memory.
+        """
+        raise NotImplementedError("Method 'save_memory' is not implemented.")
+
+    def get_model_info(self) -> dict[str, Any]:
+        """
+        Returns the model information of the agent.
+        """
+        return {}
 
 
 class AgentBackend:
@@ -59,8 +107,9 @@ class AgentBackend:
         self,
         task: Optional[Task],
         *,
-        agent_name: Optional[str] = None,
+        agent_key: Optional[str] = None,
         memory: Optional[Memory] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ) -> Agent:
         raise NotImplementedError
@@ -78,15 +127,16 @@ class AgentFactory:
         cls,
         task: Optional[Task],
         backend: str = DEFAULT_BACKEND,
-        agent_name: Optional[str] = None,
+        agent_key: Optional[str] = None,
         memory: Optional[Memory] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ):
         """
         Abstract method to create and return an Agent instance.
         """
         return cls.backends[backend.lower()].create_agent(
-            task, agent_name=agent_name, memory=memory, **kwargs
+            task, agent_key=agent_key, memory=memory, callback=callback, **kwargs
         )
 
     @classmethod
@@ -106,3 +156,152 @@ class AgentFactory:
         Registers an agent creation backend with the given name.
         """
         cls.backends[name.lower()] = backend
+
+
+@dataclass
+class AgentRuntimeConfig:
+    agent_key: str
+    backend: str = DEFAULT_BACKEND
+    model: Optional[str] = None
+
+    @classmethod
+    def from_agent(cls, *, agent_key: str, agent: Agent) -> "AgentRuntimeConfig":
+        model_info = agent.get_model_info()
+        backend = model_info.get("backend") if isinstance(model_info, dict) else None
+        model = model_info.get("model") if isinstance(model_info, dict) else None
+        backend_obj = AgentFactory.default_backend()
+        return cls(
+            agent_key=agent_key,
+            backend=str(backend or backend_obj.backend),
+            model=model or backend_obj.model,
+        )
+
+    @classmethod
+    def from_record(
+        cls, agent_key: str, record: dict[str, Any]
+    ) -> "AgentRuntimeConfig":
+        runtime_config = record.get("runtimeConfig")
+        if not isinstance(runtime_config, dict):
+            runtime_config = {}
+        model_info = record.get("modelInfo")
+        if not isinstance(model_info, dict):
+            model_info = {}
+        backend = str(
+            runtime_config.get("backend")
+            or model_info.get("backend")
+            or DEFAULT_BACKEND
+        )
+        return cls(
+            agent_key=agent_key,
+            backend=backend,
+            model=runtime_config.get("model") or model_info.get("model"),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "agentKey": self.agent_key,
+            "backend": self.backend,
+            "model": self.model,
+        }
+
+
+def create_agent_for_runtime_config(
+    *,
+    task: Optional[Task],
+    memory: Optional[Memory],
+    runtime_config: AgentRuntimeConfig,
+    create_kwargs: Optional[dict[str, Any]] = None,
+    callback: AgentCallbackType = None,
+) -> tuple[Agent, AgentRuntimeConfig]:
+    agent = AgentFactory.create_agent(
+        task=task,
+        memory=memory,
+        agent_key=runtime_config.agent_key,
+        callback=callback,
+        **(create_kwargs or {}),
+    )
+    return agent, AgentRuntimeConfig.from_agent(
+        agent_key=runtime_config.agent_key,
+        agent=agent,
+    )
+
+
+def verify_restored_agent_config(
+    saved_config: AgentRuntimeConfig, current_config: AgentRuntimeConfig
+) -> None:
+    if saved_config.backend != current_config.backend:
+        raise RuntimeError(
+            "Cannot restore agent session with mismatched backend for "
+            f"{saved_config.agent_key!r}: saved {saved_config.backend!r}, "
+            f"current {current_config.backend!r}."
+        )
+    if (
+        saved_config.model
+        and current_config.model
+        and saved_config.model != current_config.model
+    ):
+        warnings.warn(
+            "Restoring agent session with a different model for "
+            f"{saved_config.agent_key!r}: saved {saved_config.model!r}, "
+            f"current {current_config.model!r}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def serialize_agent_session(
+    agent_key: str, agent: Agent, runtime_config: AgentRuntimeConfig
+) -> dict[str, Any]:
+    task_json = None
+    task = agent.task
+    if task is not None:
+        task_json = task.to_json()
+    return {
+        "agentKey": agent_key,
+        "runtimeConfig": runtime_config.to_json(),
+        "memory": agent.save_memory(),
+        "modelInfo": agent.get_model_info(),
+        "task": task_json,
+    }
+
+
+def restore_agent_session(
+    agent_key: str,
+    record: dict[str, Any],
+    *,
+    memory: Optional[Memory],
+) -> tuple[Agent, AgentRuntimeConfig]:
+    task = None
+    task_json = record.get("task")
+    if isinstance(task_json, dict):
+        try:
+            task = Task.from_json(task_json)
+        except Exception as exc:
+            warnings.warn(
+                f"Failed to restore task for agent {agent_key!r}; "
+                f"creating the agent with no task. Original error: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    saved_config = AgentRuntimeConfig.from_record(agent_key, record)
+    agent, current_config = create_agent_for_runtime_config(
+        task=task,
+        memory=memory,
+        runtime_config=saved_config,
+    )
+    verify_restored_agent_config(saved_config, current_config)
+
+    memory_json = record.get("memory")
+    if memory_json:
+        try:
+            agent.load_memory(str(memory_json))
+        except Exception as exc:
+            warnings.warn(
+                f"Failed to restore memory for agent {agent_key!r}; "
+                "continuing with an empty live agent session. "
+                f"Original error: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    return agent, current_config

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from typing import Any, Awaitable, Callable, Optional, Union, List, Literal
+from typing import Any, Callable, Optional, Union, List, Literal
 
 from loguru import logger
 
@@ -34,7 +34,6 @@ from charge.clients.agent_factory import (
     AgentBackend,
     Agent,
     AgentCallbackType,
-    ReasoningCallbackType,
 )
 from charge.clients.agentframework_utils import (
     POSSIBLE_CONNECTION_ERRORS,
@@ -381,7 +380,6 @@ class AgentFrameworkAgent(Agent):
         agent: AFAgent,
         user_prompt: str | list[Content],
         session: AgentSession,
-        reasoning_callback: ReasoningCallbackType,
     ) -> str:
         """
         Executes the agent with retry logic and output validation.
@@ -390,9 +388,6 @@ class AgentFrameworkAgent(Agent):
             agent: The agent instance to run.
             user_prompt: The prompt to send to the agent.
             session: The agent session for conversation state.
-            reasoning_callback: An optional function to be called whenever a
-                                reasoning summary is generated.
-
         Returns:
             Valid output content as a string.
 
@@ -425,8 +420,11 @@ class AgentFrameworkAgent(Agent):
                             or "thinking_summary" in raw_type
                         ) and raw_type.endswith(".done"):
                             # Reasoning summary - use callback to transmit back
-                            if reasoning_callback and update.contents[0].text:
-                                await reasoning_callback(update.contents[0].text)
+                            if self.callback is not None and update.contents[0].text:
+                                await self.callback.on_reasoning_update(
+                                    update.contents[0].text,
+                                    source=self.agent_key,
+                                )
                                 logger.debug(
                                     f"Captured reasoning summary from event: {raw_type}"
                                 )
@@ -591,9 +589,7 @@ class AgentFrameworkAgent(Agent):
             logger.error(f"Failed to convert to structured format: {e}")
             raise ValueError(f"Structured output conversion failed: {e}") from e
 
-    async def run(
-        self, reasoning_callback: ReasoningCallbackType = None, **kwargs
-    ) -> str:
+    async def run(self, **kwargs) -> str:
         """
         Runs the agent.
 
@@ -630,7 +626,7 @@ class AgentFrameworkAgent(Agent):
 
             # Execute with retries
             result = await self._execute_with_retries(
-                self._af_agent, user_prompt, self._agent_session, reasoning_callback
+                self._af_agent, user_prompt, self._agent_session
             )
             return result
 

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -76,14 +76,25 @@ def _usage_details_to_dict(usage_details: Any) -> dict[str, int]:
             for key in (
                 "input_token_count",
                 "output_token_count",
+                "reasoning_token_count",
                 "total_token_count",
             )
         }
+        output_details = getattr(usage_details, "output_tokens_details", None)
+        if output_details is not None:
+            source["reasoning_token_count"] = getattr(
+                output_details, "reasoning_tokens", None
+            )
     mapping = {
         "input_token_count": "inputTokens",
         "output_token_count": "outputTokens",
+        "reasoning_token_count": "reasoningTokens",
         "total_token_count": "totalTokens",
     }
+    if isinstance(source.get("output_tokens_details"), dict):
+        reasoning_tokens = source["output_tokens_details"].get("reasoning_tokens")
+        if isinstance(reasoning_tokens, int):
+            source["reasoning_token_count"] = reasoning_tokens
     for source_key, target_key in mapping.items():
         value = source.get(source_key)
         if isinstance(value, int):

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -64,6 +64,39 @@ def _wrap_agentframework_builtin_tool(tool_obj: Any) -> Any:
     return wrapped_tool
 
 
+def _usage_details_to_dict(usage_details: Any) -> dict[str, int]:
+    if not usage_details:
+        return {}
+    usage: dict[str, int] = {}
+    if isinstance(usage_details, dict):
+        source = usage_details
+    else:
+        source = {
+            key: getattr(usage_details, key, None)
+            for key in (
+                "input_token_count",
+                "output_token_count",
+                "total_token_count",
+            )
+        }
+    mapping = {
+        "input_token_count": "inputTokens",
+        "output_token_count": "outputTokens",
+        "total_token_count": "totalTokens",
+    }
+    for source_key, target_key in mapping.items():
+        value = source.get(source_key)
+        if isinstance(value, int):
+            usage[target_key] = value
+    if "totalTokens" not in usage and (
+        "inputTokens" in usage or "outputTokens" in usage
+    ):
+        usage["totalTokens"] = usage.get("inputTokens", 0) + usage.get(
+            "outputTokens", 0
+        )
+    return usage
+
+
 def create_agentframework_client(
     backend: str,
     model: str,
@@ -179,6 +212,7 @@ class AgentFrameworkAgent(Agent):
         self._agent_signature: Optional[tuple[Any, ...]] = None
 
         self._agent_session: Optional[AgentSession] = None
+        self._last_usage: dict[str, int] = {}
 
     def _resolve_builtin_tools(self) -> list[Any]:
         task_builtin_tools = (
@@ -443,6 +477,9 @@ class AgentFrameworkAgent(Agent):
                                     call_id=call_id,
                                 )
                 result = await stream.get_final_response()
+                self._last_usage = _usage_details_to_dict(
+                    getattr(result, "usage_details", None)
+                )
 
                 # Extract content from result
                 proposed_content = ""
@@ -599,6 +636,7 @@ class AgentFrameworkAgent(Agent):
             "model": self.model,
             "backend": self.backend,
             "model_kwargs": self.model_kwargs,
+            "lastUsage": self._last_usage,
         }
 
     def load_memory(self, json_str: str) -> None:

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -34,7 +34,6 @@ from charge.clients.agent_factory import (
     AgentBackend,
     Agent,
     AgentCallbackType,
-    AgentInstructionSnapshot,
     ReasoningCallbackType,
 )
 from charge.clients.agentframework_utils import (
@@ -626,16 +625,17 @@ class AgentFrameworkAgent(Agent):
 
             # Prepare prompt
             user_prompt = self._prepare_task_prompt()
+            self.begin_task_run()
+            await self.notify_task_start()
 
             # Execute with retries
             result = await self._execute_with_retries(
                 self._af_agent, user_prompt, self._agent_session, reasoning_callback
             )
-            self._capture_instruction_snapshot(instructions)
-
             return result
 
         finally:
+            self.finish_task_run()
             await self.close_workbenches()
 
     def get_model_info(self) -> dict[str, Any]:
@@ -662,37 +662,6 @@ class AgentFrameworkAgent(Agent):
         if self._agent_session is None:
             return ""
         return json.dumps(self._agent_session.to_dict())
-
-    @staticmethod
-    def _session_messages(session: AgentSession) -> list[dict[str, Any]]:
-        session_dict = session.to_dict()
-        messages = (
-            session_dict.get("state", {}).get("in_memory", {}).get("messages", [])
-        )
-        return messages if isinstance(messages, list) else []
-
-    def _capture_instruction_snapshot(self, instructions: str) -> None:
-        if self._agent_session is None:
-            return
-        instructions = instructions.strip()
-        if not instructions:
-            return
-
-        message_count = len(self._session_messages(self._agent_session))
-        if message_count <= 0:
-            return
-
-        snapshot = AgentInstructionSnapshot(
-            message_count=message_count,
-            instructions=instructions,
-        )
-        if (
-            self.instruction_history
-            and self.instruction_history[-1].message_count == message_count
-        ):
-            self.instruction_history[-1] = snapshot
-        else:
-            self.instruction_history.append(snapshot)
 
 
 class AgentFrameworkBackend(AgentBackend):

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -206,19 +206,6 @@ class AgentFrameworkAgent(Agent):
             getattr(tool_obj, "__name__", repr(tool_obj))
             for tool_obj in self._resolve_builtin_tools()
         )
-        attachments = (
-            tuple(
-                (
-                    str(attachment.get("id", "")),
-                    str(attachment.get("mimeType", "")),
-                    str(attachment.get("dataUrl", "")),
-                )
-                for attachment in (getattr(self.task, "attachments", []) or [])
-                if isinstance(attachment, dict)
-            )
-            if self.task is not None
-            else ()
-        )
         server_files = tuple(self.task.server_files or []) if self.task else ()
         server_urls = tuple(self.task.server_urls or []) if self.task else ()
         mcp_server_allowed_tools = (
@@ -240,7 +227,6 @@ class AgentFrameworkAgent(Agent):
             server_urls,
             builtin_tool_names,
             mcp_server_allowed_tools,
-            attachments,
         )
 
     def _create_agent(
@@ -587,7 +573,6 @@ class AgentFrameworkAgent(Agent):
                     self.agent_name, self.reasoning_effort, instructions=instructions
                 )
                 self._agent_signature = agent_signature
-                self._agent_session = None
 
             # Create or reuse session for stateful conversation
             if self._agent_session is None:

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -34,6 +34,7 @@ from charge.clients.agent_factory import (
     AgentBackend,
     Agent,
     AgentCallbackType,
+    AgentInstructionSnapshot,
     ReasoningCallbackType,
 )
 from charge.clients.agentframework_utils import (
@@ -610,10 +611,10 @@ class AgentFrameworkAgent(Agent):
         try:
             # Create agent
             agent_signature = self._get_agent_signature()
+            instructions = (
+                self.task.get_system_prompt() if self.task is not None else ""
+            )
             if self._af_agent is None or self._agent_signature != agent_signature:
-                instructions = (
-                    self.task.get_system_prompt() if self.task is not None else ""
-                )
                 self._af_agent = self._create_agent(
                     self.agent_key, self.reasoning_effort, instructions=instructions
                 )
@@ -630,6 +631,7 @@ class AgentFrameworkAgent(Agent):
             result = await self._execute_with_retries(
                 self._af_agent, user_prompt, self._agent_session, reasoning_callback
             )
+            self._capture_instruction_snapshot(instructions)
 
             return result
 
@@ -660,6 +662,37 @@ class AgentFrameworkAgent(Agent):
         if self._agent_session is None:
             return ""
         return json.dumps(self._agent_session.to_dict())
+
+    @staticmethod
+    def _session_messages(session: AgentSession) -> list[dict[str, Any]]:
+        session_dict = session.to_dict()
+        messages = (
+            session_dict.get("state", {}).get("in_memory", {}).get("messages", [])
+        )
+        return messages if isinstance(messages, list) else []
+
+    def _capture_instruction_snapshot(self, instructions: str) -> None:
+        if self._agent_session is None:
+            return
+        instructions = instructions.strip()
+        if not instructions:
+            return
+
+        message_count = len(self._session_messages(self._agent_session))
+        if message_count <= 0:
+            return
+
+        snapshot = AgentInstructionSnapshot(
+            message_count=message_count,
+            instructions=instructions,
+        )
+        if (
+            self.instruction_history
+            and self.instruction_history[-1].message_count == message_count
+        ):
+            self.instruction_history[-1] = snapshot
+        else:
+            self.instruction_history.append(snapshot)
 
 
 class AgentFrameworkBackend(AgentBackend):

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -81,6 +81,7 @@ def _usage_details_to_dict(usage_details: Any) -> dict[str, int]:
                 "input_token_count",
                 "output_token_count",
                 "reasoning_token_count",
+                "openai.reasoning_tokens",
                 "total_token_count",
             )
         }
@@ -93,6 +94,7 @@ def _usage_details_to_dict(usage_details: Any) -> dict[str, int]:
         "input_token_count": "inputTokens",
         "output_token_count": "outputTokens",
         "reasoning_token_count": "reasoningTokens",
+        "openai.reasoning_tokens": "reasoningTokens",
         "total_token_count": "totalTokens",
     }
     if isinstance(source.get("output_tokens_details"), dict):

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -636,6 +636,7 @@ class AgentFrameworkAgent(Agent):
 
         finally:
             self.finish_task_run()
+            await self.notify_task_finish()
             await self.close_workbenches()
 
     def get_model_info(self) -> dict[str, Any]:

--- a/charge/clients/agentframework.py
+++ b/charge/clients/agentframework.py
@@ -30,7 +30,12 @@ except ImportError:
         "Install with: pip install 'charge[agentframework]'"
     )
 
-from charge.clients.agent_factory import AgentBackend, Agent, ReasoningCallbackType
+from charge.clients.agent_factory import (
+    AgentBackend,
+    Agent,
+    AgentCallbackType,
+    ReasoningCallbackType,
+)
 from charge.clients.agentframework_utils import (
     POSSIBLE_CONNECTION_ERRORS,
     setup_mcp_tools,
@@ -177,7 +182,7 @@ class AgentFrameworkAgent(Agent):
     Args:
         task (Task): The task to be performed by the agent.
         client: The Agent Framework client.
-        agent_name (str): Name of the agent.
+        agent_key (str): Name of the agent.
         model (str): Model name.
         memory (Optional[Any], optional): Memory instance for conversation state. Defaults to None.
         max_retries (int, optional): Maximum number of retries. Defaults to 3.
@@ -190,7 +195,7 @@ class AgentFrameworkAgent(Agent):
         self,
         task: Optional[Task],
         client: OpenAIChatClient,
-        agent_name: str,
+        agent_key: str,
         model: str | None,
         memory: Optional[Memory] = None,
         max_retries: int = 3,
@@ -200,21 +205,19 @@ class AgentFrameworkAgent(Agent):
         model_kwargs: Optional[dict] = None,
         reasoning_effort: Literal["low", "medium", "high"] = "medium",
         builtin_tools: Optional[list[Any]] = None,
-        callback: Optional[Any] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ) -> None:
-        super().__init__(task=task, **kwargs)
+        super().__init__(task=task, callback=callback, **kwargs)
         self.max_retries = max_retries
         self.max_tool_calls = max_tool_calls
         self.workbenches: List[Any] = []  # Will be MCP workbenches
         self.builtin_tools = builtin_tools or []
-        self.agent_name = agent_name
+        self.agent_key = agent_key
         self.client = client
         self.timeout = timeout
         self.setup_kwargs = kwargs
         self.reasoning_effort = reasoning_effort
-        self.callback = callback
-
         self.model = model
         self.backend = backend
         self.model_kwargs = model_kwargs if model_kwargs is not None else {}
@@ -276,13 +279,13 @@ class AgentFrameworkAgent(Agent):
 
     def _create_agent(
         self,
-        agent_name: str,
+        agent_key: str,
         reasoning_effort: Literal["low", "medium", "high"],
         instructions: str,
     ) -> AFAgent:
         af_agent = AFAgent[OpenAIChatOptions](
             client=self.client,
-            name=agent_name,
+            name=agent_key,
             instructions=instructions,
             tools=self.workbenches,
             default_options={
@@ -438,53 +441,47 @@ class AgentFrameworkAgent(Agent):
                             if call_id and tool_name:
                                 tool_call_names[call_id] = tool_name
                             if self.callback is not None and tool_name and call_id:
-                                if hasattr(self.callback, "on_tool_call"):
-                                    await maybe_await_async(
-                                        self.callback.on_tool_call,
-                                        tool_name,
-                                        content.arguments,
-                                        source=self.agent_name,
-                                        call_id=call_id,
-                                    )
+                                await maybe_await_async(
+                                    self.callback.on_tool_call,
+                                    tool_name,
+                                    content.arguments,
+                                    source=self.agent_key,
+                                    call_id=call_id,
+                                )
                         elif content_type == "mcp_server_tool_call":
                             call_id = content.call_id
                             tool_name = content.tool_name
                             if call_id and tool_name:
                                 tool_call_names[call_id] = tool_name
                             if self.callback is not None and tool_name and call_id:
-                                if hasattr(self.callback, "on_tool_call"):
-                                    await maybe_await_async(
-                                        self.callback.on_tool_call,
-                                        tool_name,
-                                        content.arguments,
-                                        source=self.agent_name,
-                                        call_id=call_id,
-                                    )
+                                await maybe_await_async(
+                                    self.callback.on_tool_call,
+                                    tool_name,
+                                    content.arguments,
+                                    source=self.agent_key,
+                                    call_id=call_id,
+                                )
                         elif content_type == "function_result":
                             call_id = content.call_id
                             tool_name = tool_call_names.get(call_id or "", "tool")
-                            if self.callback is not None and hasattr(
-                                self.callback, "on_tool_result"
-                            ):
+                            if self.callback is not None:
                                 await maybe_await_async(
                                     self.callback.on_tool_result,
                                     tool_name,
                                     content.result,
                                     is_error=bool(content.exception),
-                                    source=self.agent_name,
+                                    source=self.agent_key,
                                     call_id=call_id,
                                 )
                         elif content_type == "mcp_server_tool_result":
                             call_id = content.call_id
                             tool_name = tool_call_names.get(call_id or "", "tool")
-                            if self.callback is not None and hasattr(
-                                self.callback, "on_tool_result"
-                            ):
+                            if self.callback is not None:
                                 await maybe_await_async(
                                     self.callback.on_tool_result,
                                     tool_name,
                                     content.output,
-                                    source=self.agent_name,
+                                    source=self.agent_key,
                                     call_id=call_id,
                                 )
                 result = await stream.get_final_response()
@@ -570,7 +567,7 @@ class AgentFrameworkAgent(Agent):
             schema = structured_out.model_json_schema()
 
             conversion_agent = self._create_agent(
-                f"{self.agent_name}_structured_output",
+                f"{self.agent_key}_structured_output",
                 reasoning_effort="low",
                 instructions="You are an agent that converts model output to a structured JSON format.",
             )
@@ -605,7 +602,7 @@ class AgentFrameworkAgent(Agent):
                  the output will be checked with the task's formatting method and
                  the json string will be returned.
         """
-        logger.info(f"Running Agent Framework agent: {self.agent_name}")
+        logger.info(f"Running Agent Framework agent: {self.agent_key}")
 
         # Set up workbenches from task server paths
         await self.setup_mcp_workbenches()
@@ -618,7 +615,7 @@ class AgentFrameworkAgent(Agent):
                     self.task.get_system_prompt() if self.task is not None else ""
                 )
                 self._af_agent = self._create_agent(
-                    self.agent_name, self.reasoning_effort, instructions=instructions
+                    self.agent_key, self.reasoning_effort, instructions=instructions
                 )
                 self._agent_signature = agent_signature
 
@@ -741,8 +738,9 @@ class AgentFrameworkBackend(AgentBackend):
         self,
         task: Optional[Task],
         max_retries: int = 3,
-        agent_name: Optional[str] = None,
+        agent_key: Optional[str] = None,
         memory: Optional[Memory] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ) -> AgentFrameworkAgent:
         self.max_retries = max_retries
@@ -751,19 +749,20 @@ class AgentFrameworkBackend(AgentBackend):
         ), "Chat client must be initialized to create an agent."
 
         AgentFrameworkBackend.AGENT_COUNT += 1
-        default_name = f"af_agent_{AgentFrameworkBackend.AGENT_COUNT}"
-        agent_name = default_name if agent_name is None else agent_name
+        default_key = f"af_agent_{AgentFrameworkBackend.AGENT_COUNT}"
+        agent_key = default_key if agent_key is None else agent_key
 
         agent = AgentFrameworkAgent(
             task=task,
             client=self.client,
-            agent_name=agent_name,
+            agent_key=agent_key,
             max_retries=max_retries,
             model=self.model,
             backend=self.backend,
             model_kwargs=self.model_kwargs,
             memory=memory,
             reasoning_effort=self.reasoning_effort,
+            callback=callback,
             **kwargs,
         )
         return agent

--- a/charge/clients/autogen.py
+++ b/charge/clients/autogen.py
@@ -40,7 +40,6 @@ from charge.clients.agent_factory import (
     AgentFactory,
     Agent,
     AgentCallbackType,
-    ReasoningCallbackType,
 )
 from charge.clients.client import Client
 from charge.clients.huggingface_client import HuggingFaceLocalClient
@@ -500,9 +499,7 @@ class AutoGenAgent(Agent):
             f"Last error: {last_error}"
         )
 
-    async def run(
-        self, reasoning_callback: ReasoningCallbackType = None, **kwargs
-    ) -> str:
+    async def run(self, **kwargs) -> str:
         """
         Runs the agent.
 

--- a/charge/clients/autogen.py
+++ b/charge/clients/autogen.py
@@ -519,8 +519,11 @@ class AutoGenAgent(Agent):
         try:
             agent = self._create_agent()
             user_prompt = self._prepare_task_prompt()
+            self.begin_task_run()
+            await self.notify_task_start()
             result = await self._execute_with_retries(agent, user_prompt)
         finally:
+            self.finish_task_run()
             await self.close_workbenches()
 
         return result

--- a/charge/clients/autogen.py
+++ b/charge/clients/autogen.py
@@ -524,6 +524,7 @@ class AutoGenAgent(Agent):
             result = await self._execute_with_retries(agent, user_prompt)
         finally:
             self.finish_task_run()
+            await self.notify_task_finish()
             await self.close_workbenches()
 
         return result

--- a/charge/clients/autogen.py
+++ b/charge/clients/autogen.py
@@ -39,6 +39,7 @@ from charge.clients.agent_factory import (
     AgentBackend,
     AgentFactory,
     Agent,
+    AgentCallbackType,
     ReasoningCallbackType,
 )
 from charge.clients.client import Client
@@ -230,7 +231,7 @@ class AutoGenAgent(Agent):
         self,
         task: Optional[Task],
         model_client: Union[AsyncOpenAI, ChatCompletionClient],
-        agent_name: str,
+        agent_key: str,
         model: str,
         memory: Optional[Any] = None,
         max_retries: int = 3,
@@ -239,14 +240,15 @@ class AutoGenAgent(Agent):
         backend: Optional[str] = None,
         model_kwargs: Optional[dict] = None,
         builtin_tools: Optional[list[Any]] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ) -> None:
-        super().__init__(task=task, **kwargs)
+        super().__init__(task=task, callback=callback, **kwargs)
         self.max_retries = max_retries
         self.max_tool_calls = max_tool_calls
         self.workbenches: List[McpWorkbench] = []
         self.builtin_tools = builtin_tools or []
-        self.agent_name = agent_name
+        self.agent_key = agent_key
         self.model_client = model_client
         self.timeout = timeout
         self.memory: list[ChARGeListMemory] | ChARGeListMemory = self.setup_memory(
@@ -254,7 +256,6 @@ class AutoGenAgent(Agent):
         )
         self.setup_kwargs = kwargs
 
-        self.context_history = []
         self.model = model
         self.backend = backend
         self.model_kwargs = model_kwargs if model_kwargs is not None else {}
@@ -339,7 +340,7 @@ class AutoGenAgent(Agent):
             self.task.get_system_prompt(),
             self.workbenches,
             max_tool_calls=self.max_tool_calls,
-            name=self.agent_name,
+            name=self.agent_key,
             memory=self.memory,
             builtin_tools=self._get_wrapped_builtin_tools(),
             **self.setup_kwargs,
@@ -413,7 +414,7 @@ class AutoGenAgent(Agent):
             assert self.task is not None
             self._structured_output_agent = generate_agent(
                 self.model_client,
-                f"{self.agent_name}_structured_output",
+                f"{self.agent_key}_structured_output",
                 "You are an agent that converts model output to a structured format.",
                 [],  # No tools needed
                 max_tool_calls=1,
@@ -444,7 +445,6 @@ class AutoGenAgent(Agent):
             try:
                 logger.info(f"Attempt {attempt}/{self.max_retries}")
                 result = await agent.run(task=user_prompt)
-                self.context_history.append(result)
 
                 if not result.messages:
                     logger.warning(f"Attempt {attempt}: No messages in result")
@@ -584,18 +584,6 @@ class AutoGenAgent(Agent):
             await self.model_client.close()
         return agent_state
 
-    def get_context_history(self) -> list:
-        """
-        Returns the context history of the agent.
-        """
-        return self.context_history
-
-    def load_context_history(self, history: list) -> None:
-        """
-        Loads the context history into the agent.
-        """
-        self.context_history = history
-
     def load_memory(self, json_str: str) -> None:
         """
         Loads memory content into the agent's memory.
@@ -645,7 +633,7 @@ class AutoGenAgent(Agent):
             mime_type=MemoryMimeType.TEXT,
         )
 
-        name = self.agent_name or "Agent"
+        name = self.agent_key or "Agent"
         if isinstance(self.memory, list):
             await self.memory[-1].add(content, source_agent=name)
         else:
@@ -666,7 +654,7 @@ class AutoGenAgent(Agent):
             mime_type=MemoryMimeType.TEXT,
         )
 
-        name = self.agent_name or "Agent"
+        name = self.agent_key or "Agent"
         if isinstance(self.memory, list):
             self.memory[-1].add_sync(content, source_agent=name)
         else:
@@ -748,15 +736,16 @@ class AutoGenBackend(AgentBackend):
         self,
         task: Optional[Task],
         max_retries: int = 3,
-        agent_name: Optional[str] = None,
+        agent_key: Optional[str] = None,
         memory: Optional[Memory] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ):
         """Creates an AutoGen agent for the given task.
         Args:
             task (Task): The task to be performed by the agent.
             max_retries (int, optional): Maximum number of retries for failed tasks. Defaults to 3.
-            agent_name (Optional[str], optional): Name of the agent. If None, a default name will be assigned. Defaults to None.
+            agent_key (Optional[str], optional): Name of the agent. If None, a default name will be assigned. Defaults to None.
             **kwargs: Additional keyword arguments.
         Returns:
             AutoGenAgent: The created AutoGen agent.
@@ -768,17 +757,18 @@ class AutoGenBackend(AgentBackend):
 
         AutoGenBackend.AGENT_COUNT += 1
 
-        default_name = f"autogen_agent_{AutoGenBackend.AGENT_COUNT}"
-        agent_name = default_name if agent_name is None else agent_name
+        default_key = f"autogen_agent_{AutoGenBackend.AGENT_COUNT}"
+        agent_key = default_key if agent_key is None else agent_key
 
         agent = AutoGenAgent(
             task=task,
             model_client=self.model_client,
-            agent_name=agent_name,
+            agent_key=agent_key,
             max_retries=max_retries,
             model=self.model,  # type: ignore
             backend=self.backend,
             model_kwargs=self.model_kwargs,
+            callback=callback,
             **kwargs,
         )
         # Add memory

--- a/charge/clients/vllm_client.py
+++ b/charge/clients/vllm_client.py
@@ -120,24 +120,12 @@ class VLLMClient(ChatCompletionClient):
         return self._model_info
 
     def count_tokens(self, messages: List[Any], **kwargs) -> int:
-        """Estimate token count (rough approximation)"""
-        # Rough estimate: 4 chars per token
-        total_chars = sum(
-            len(
-                str(
-                    m.get("content", "")
-                    if isinstance(m, dict)
-                    else getattr(m, "content", "")
-                )
-            )
-            for m in messages
-        )
-        return total_chars // 4
+        """Return token count if available."""
+        raise NotImplementedError("vLLM token counts are unavailable")
 
     def remaining_tokens(self, messages: List[Any], **kwargs) -> int:
-        """Return remaining tokens available"""
-        used = self.count_tokens(messages, **kwargs)
-        return max(0, 8192 - used)  # Assume 8K context
+        """Return remaining tokens if available."""
+        raise NotImplementedError("vLLM remaining token count is unavailable")
 
     def total_usage(self) -> dict:
         """Return total token usage"""

--- a/charge/experiments/experiment.py
+++ b/charge/experiments/experiment.py
@@ -1,9 +1,27 @@
-from typing import Any, Callable, List, Union, Optional
+from dataclasses import dataclass
+from typing import Any, List, Union, Optional
 from charge.tasks.task import Task
-from charge.clients.agent_factory import Agent, AgentFactory, ReasoningCallbackType
+from charge.clients.agent_factory import (
+    Agent,
+    AgentCallbackType,
+    AgentFactory,
+    AgentRuntimeConfig,
+    ReasoningCallbackType,
+    create_agent_for_runtime_config,
+    restore_agent_session,
+    serialize_agent_session,
+)
 from charge.experiments.memory import Memory, ListMemory
 from charge._utils import maybe_await_async
 import asyncio
+import json
+
+
+@dataclass
+class AgentRegistryEntry:
+    agent_key: str
+    agent: Agent
+    runtime_config: AgentRuntimeConfig
 
 
 class Experiment:
@@ -19,9 +37,7 @@ class Experiment:
         self.tasks = task if isinstance(task, list) else [task]
         self.finished_tasks = []
         self.memory = memory or ListMemory()
-        self.agent_registry: dict[str, dict[str, Any]] = {}
-        self.saved_agent_sessions: dict[str, dict[str, Any]] = {}
-
+        self.agent_registry: dict[str, AgentRegistryEntry] = {}
         self.args = args
         self.kwargs = kwargs
 
@@ -30,39 +46,42 @@ class Experiment:
         task,
         *,
         agent_key: Optional[str] = None,
-        agent_metadata: Optional[dict[str, Any]] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ):
         # Create an agent that incorporates the experiment state
         # NOTE: Should self.context be passed into the agent?
         if agent_key and agent_key in self.agent_registry:
             registry_item = self.agent_registry[agent_key]
-            agent = registry_item["agent"]
+            agent = registry_item.agent
             if task is not None:
                 agent.task = task
-            if "callback" in kwargs:
-                setattr(agent, "callback", kwargs["callback"])
-            if agent_metadata:
-                registry_item["metadata"] = {
-                    **registry_item.get("metadata", {}),
-                    **agent_metadata,
-                }
+            if callback is not None:
+                agent.callback = callback
             return agent
 
-        agent = AgentFactory.create_agent(task=task, memory=self.memory, **kwargs)
         if agent_key:
-            saved_session = self.saved_agent_sessions.get(agent_key, {})
-            saved_memory = saved_session.get("memory")
-            if saved_memory and hasattr(agent, "load_memory"):
-                agent.load_memory(saved_memory)
-            self.agent_registry[agent_key] = {
-                "agent": agent,
-                "metadata": {
-                    **saved_session.get("metadata", {}),
-                    **(agent_metadata or {}),
-                },
-                "messageMetadata": saved_session.get("messageMetadata", {}),
-            }
+            runtime_config = AgentRuntimeConfig(agent_key=agent_key)
+            agent, runtime_config = create_agent_for_runtime_config(
+                task=task,
+                memory=self.memory,
+                runtime_config=runtime_config,
+                create_kwargs=kwargs,
+                callback=callback,
+            )
+            self.agent_registry[agent_key] = AgentRegistryEntry(
+                agent_key=agent_key,
+                agent=agent,
+                runtime_config=runtime_config,
+            )
+            return agent
+
+        agent = AgentFactory.create_agent(
+            task=task,
+            memory=self.memory,
+            callback=callback,
+            **kwargs,
+        )
         return agent
 
     def add_to_context(self, agent: Agent, task: Task, result: Any):
@@ -72,36 +91,36 @@ class Experiment:
     def save_state(self):
         # Save the state of the experiment
         state = self.memory.to_json()
-        agent_sessions = dict(self.saved_agent_sessions)
+        agent_sessions = {}
         for agent_key, registry_item in self.agent_registry.items():
-            agent = registry_item["agent"]
-            memory = ""
-            if hasattr(agent, "save_memory"):
-                memory = agent.save_memory()
-            model_info = {}
-            if hasattr(agent, "get_model_info"):
-                model_info = agent.get_model_info()
-            task_json = None
-            task = getattr(agent, "task", None)
-            if task is not None and hasattr(task, "to_json"):
-                task_json = task.to_json()
-            agent_sessions[agent_key] = {
-                "agentKey": agent_key,
-                "metadata": registry_item.get("metadata", {}),
-                "memory": memory,
-                "modelInfo": model_info,
-                "task": task_json,
-                "messageMetadata": registry_item.get("messageMetadata", {}),
-            }
+            agent_sessions[agent_key] = serialize_agent_session(
+                agent_key, registry_item.agent, registry_item.runtime_config
+            )
         if agent_sessions:
             state["agentSessions"] = agent_sessions
         return state
 
     def load_state(self, state):
         # Load the state of the experiment
+        if isinstance(state, str):
+            state = json.loads(state)
         self.memory = ListMemory.from_json(state)
-        self.saved_agent_sessions = state.get("agentSessions", {}) or {}
         self.agent_registry = {}
+        agent_sessions = state.get("agentSessions", {}) or {}
+        if not isinstance(agent_sessions, dict):
+            return
+        for raw_agent_key, record in agent_sessions.items():
+            if not isinstance(record, dict):
+                continue
+            agent_key = str(record.get("agentKey") or raw_agent_key)
+            agent, runtime_config = restore_agent_session(
+                agent_key, record, memory=self.memory
+            )
+            self.agent_registry[agent_key] = AgentRegistryEntry(
+                agent_key=agent_key,
+                agent=agent,
+                runtime_config=runtime_config,
+            )
 
     def num_finished_tasks(self) -> int:
         """Returns the number of finished tasks.
@@ -135,17 +154,41 @@ class Experiment:
         return self.finished_tasks
 
     async def run_async(
-        self, reasoning_callback: ReasoningCallbackType, **kwargs
+        self,
+        reasoning_callback: ReasoningCallbackType = None,
+        *,
+        agent_key: Optional[str] = None,
+        callback: AgentCallbackType = None,
+        **kwargs,
     ) -> None:
         while self.tasks:
             current_task = self.tasks.pop(0)
-            agent = self.create_agent_with_experiment_state(task=current_task, **kwargs)
+            agent = self.create_agent_with_experiment_state(
+                task=current_task,
+                agent_key=agent_key,
+                callback=callback,
+                **kwargs,
+            )
             result = await maybe_await_async(agent.run, reasoning_callback)
             await maybe_await_async(self.add_to_context, agent, current_task, result)
             self.finished_tasks.append((current_task, result))
 
-    def run(self, reasoning_callback: ReasoningCallbackType) -> None:
-        asyncio.run(self.run_async(reasoning_callback))
+    def run(
+        self,
+        reasoning_callback: ReasoningCallbackType = None,
+        *,
+        agent_key: Optional[str] = None,
+        callback: AgentCallbackType = None,
+        **kwargs,
+    ) -> None:
+        asyncio.run(
+            self.run_async(
+                reasoning_callback,
+                agent_key=agent_key,
+                callback=callback,
+                **kwargs,
+            )
+        )
 
     def reset(self):
         """
@@ -155,4 +198,3 @@ class Experiment:
         self.memory = ListMemory()
         self.tasks = []
         self.agent_registry = {}
-        self.saved_agent_sessions = {}

--- a/charge/experiments/experiment.py
+++ b/charge/experiments/experiment.py
@@ -19,7 +19,6 @@ import json
 
 @dataclass
 class AgentRegistryEntry:
-    agent_key: str
     agent: Agent
     runtime_config: AgentRuntimeConfig
 
@@ -61,16 +60,16 @@ class Experiment:
             return agent
 
         if agent_key:
-            runtime_config = AgentRuntimeConfig(agent_key=agent_key)
+            runtime_config = AgentRuntimeConfig()
             agent, runtime_config = create_agent_for_runtime_config(
                 task=task,
+                agent_key=agent_key,
                 memory=self.memory,
                 runtime_config=runtime_config,
                 create_kwargs=kwargs,
                 callback=callback,
             )
             self.agent_registry[agent_key] = AgentRegistryEntry(
-                agent_key=agent_key,
                 agent=agent,
                 runtime_config=runtime_config,
             )
@@ -94,7 +93,7 @@ class Experiment:
         agent_sessions = {}
         for agent_key, registry_item in self.agent_registry.items():
             agent_sessions[agent_key] = serialize_agent_session(
-                agent_key, registry_item.agent, registry_item.runtime_config
+                registry_item.agent, registry_item.runtime_config
             )
         if agent_sessions:
             state["agentSessions"] = agent_sessions
@@ -112,12 +111,11 @@ class Experiment:
         for raw_agent_key, record in agent_sessions.items():
             if not isinstance(record, dict):
                 continue
-            agent_key = str(record.get("agentKey") or raw_agent_key)
+            agent_key = str(raw_agent_key)
             agent, runtime_config = restore_agent_session(
                 agent_key, record, memory=self.memory
             )
             self.agent_registry[agent_key] = AgentRegistryEntry(
-                agent_key=agent_key,
                 agent=agent,
                 runtime_config=runtime_config,
             )

--- a/charge/experiments/experiment.py
+++ b/charge/experiments/experiment.py
@@ -6,7 +6,6 @@ from charge.clients.agent_factory import (
     AgentCallbackType,
     AgentFactory,
     AgentRuntimeConfig,
-    ReasoningCallbackType,
     create_agent_for_runtime_config,
     restore_agent_session,
     serialize_agent_session,
@@ -153,7 +152,6 @@ class Experiment:
 
     async def run_async(
         self,
-        reasoning_callback: ReasoningCallbackType = None,
         *,
         agent_key: Optional[str] = None,
         callback: AgentCallbackType = None,
@@ -167,13 +165,12 @@ class Experiment:
                 callback=callback,
                 **kwargs,
             )
-            result = await maybe_await_async(agent.run, reasoning_callback)
+            result = await maybe_await_async(agent.run)
             await maybe_await_async(self.add_to_context, agent, current_task, result)
             self.finished_tasks.append((current_task, result))
 
     def run(
         self,
-        reasoning_callback: ReasoningCallbackType = None,
         *,
         agent_key: Optional[str] = None,
         callback: AgentCallbackType = None,
@@ -181,7 +178,6 @@ class Experiment:
     ) -> None:
         asyncio.run(
             self.run_async(
-                reasoning_callback,
                 agent_key=agent_key,
                 callback=callback,
                 **kwargs,

--- a/charge/experiments/experiment.py
+++ b/charge/experiments/experiment.py
@@ -19,14 +19,51 @@ class Experiment:
         self.tasks = task if isinstance(task, list) else [task]
         self.finished_tasks = []
         self.memory = memory or ListMemory()
+        self.agent_registry: dict[str, dict[str, Any]] = {}
+        self.saved_agent_sessions: dict[str, dict[str, Any]] = {}
 
         self.args = args
         self.kwargs = kwargs
 
-    def create_agent_with_experiment_state(self, task, **kwargs):
+    def create_agent_with_experiment_state(
+        self,
+        task,
+        *,
+        agent_key: Optional[str] = None,
+        agent_metadata: Optional[dict[str, Any]] = None,
+        **kwargs,
+    ):
         # Create an agent that incorporates the experiment state
         # NOTE: Should self.context be passed into the agent?
-        return AgentFactory.create_agent(task=task, memory=self.memory, **kwargs)
+        if agent_key and agent_key in self.agent_registry:
+            registry_item = self.agent_registry[agent_key]
+            agent = registry_item["agent"]
+            if task is not None:
+                agent.task = task
+            if "callback" in kwargs:
+                setattr(agent, "callback", kwargs["callback"])
+            if agent_metadata:
+                registry_item["metadata"] = {
+                    **registry_item.get("metadata", {}),
+                    **agent_metadata,
+                }
+            return agent
+
+        agent = AgentFactory.create_agent(task=task, memory=self.memory, **kwargs)
+        if agent_key:
+            saved_session = self.saved_agent_sessions.get(agent_key, {})
+            saved_memory = saved_session.get("memory")
+            if saved_memory and hasattr(agent, "load_memory"):
+                agent.load_memory(saved_memory)
+            self.agent_registry[agent_key] = {
+                "agent": agent,
+                "metadata": {
+                    **saved_session.get("metadata", {}),
+                    **(agent_metadata or {}),
+                },
+                "messageMetadata": saved_session.get("messageMetadata", {}),
+            }
+        return agent
 
     def add_to_context(self, agent: Agent, task: Task, result: Any):
         # Add the result to the context of the experiment
@@ -34,11 +71,37 @@ class Experiment:
 
     def save_state(self):
         # Save the state of the experiment
-        return self.memory.to_json()
+        state = self.memory.to_json()
+        agent_sessions = dict(self.saved_agent_sessions)
+        for agent_key, registry_item in self.agent_registry.items():
+            agent = registry_item["agent"]
+            memory = ""
+            if hasattr(agent, "save_memory"):
+                memory = agent.save_memory()
+            model_info = {}
+            if hasattr(agent, "get_model_info"):
+                model_info = agent.get_model_info()
+            task_json = None
+            task = getattr(agent, "task", None)
+            if task is not None and hasattr(task, "to_json"):
+                task_json = task.to_json()
+            agent_sessions[agent_key] = {
+                "agentKey": agent_key,
+                "metadata": registry_item.get("metadata", {}),
+                "memory": memory,
+                "modelInfo": model_info,
+                "task": task_json,
+                "messageMetadata": registry_item.get("messageMetadata", {}),
+            }
+        if agent_sessions:
+            state["agentSessions"] = agent_sessions
+        return state
 
     def load_state(self, state):
         # Load the state of the experiment
         self.memory = ListMemory.from_json(state)
+        self.saved_agent_sessions = state.get("agentSessions", {}) or {}
+        self.agent_registry = {}
 
     def num_finished_tasks(self) -> int:
         """Returns the number of finished tasks.
@@ -91,3 +154,5 @@ class Experiment:
         self.finished_tasks = []
         self.memory = ListMemory()
         self.tasks = []
+        self.agent_registry = {}
+        self.saved_agent_sessions = {}

--- a/tests/integration_tests/test_agentframework_integration.py
+++ b/tests/integration_tests/test_agentframework_integration.py
@@ -126,7 +126,7 @@ class TestAgentFrameworkIntegration:
         import re
 
         # Run the experiment with two tasks
-        await self.experiment.run_async(backend="agentframework")
+        await self.experiment.run_async()
         finished_tasks = self.experiment.get_finished_tasks()
         assert len(finished_tasks) == 2
 
@@ -157,7 +157,7 @@ class TestAgentFrameworkIntegration:
         self.experiment.add_task(self.third_task)
         assert self.experiment.remaining_tasks() == 1
 
-        await self.experiment.run_async(backend="agentframework")
+        await self.experiment.run_async()
         finished_tasks = self.experiment.get_finished_tasks()
         assert len(finished_tasks) == 3
 
@@ -185,7 +185,7 @@ class TestAgentFrameworkIntegration:
         self.experiment.add_task(self.alternate_third_task)
         assert self.experiment.remaining_tasks() == 1
 
-        await self.experiment.run_async(backend="agentframework")
+        await self.experiment.run_async()
         finished_tasks = self.experiment.get_finished_tasks()
 
         third_task, third_task_result = finished_tasks[-1]
@@ -215,7 +215,7 @@ class TestAgentFrameworkIntegration:
         experiment.add_task(task1)
         experiment.add_task(task2)
 
-        await experiment.run_async(backend="agentframework")
+        await experiment.run_async()
         finished_tasks = experiment.get_finished_tasks()
 
         assert len(finished_tasks) == 2

--- a/tests/unit_tests/test_agentframework_attachments.py
+++ b/tests/unit_tests/test_agentframework_attachments.py
@@ -19,7 +19,7 @@ def test_agentframework_prepares_multimodal_prompt_for_attachments():
     agent = AgentFrameworkAgent(
         task=task,
         client=object(),
-        agent_name="test",
+        agent_key="test",
         model="test-model",
     )
 
@@ -51,7 +51,7 @@ def test_agentframework_signature_does_not_include_turn_attachments():
     agent = AgentFrameworkAgent(
         task=task,
         client=object(),
-        agent_name="test",
+        agent_key="test",
         model="test-model",
     )
 

--- a/tests/unit_tests/test_agentframework_attachments.py
+++ b/tests/unit_tests/test_agentframework_attachments.py
@@ -31,3 +31,31 @@ def test_agentframework_prepares_multimodal_prompt_for_attachments():
     assert prompt[1].type == "data"
     assert prompt[1].media_type == "image/png"
     assert prompt[1].uri == "data:image/png;base64,ZmFrZQ=="
+
+
+def test_agentframework_signature_does_not_include_turn_attachments():
+    task = Task(
+        system_prompt="System",
+        user_prompt="Describe this image.",
+        attachments=[
+            {
+                "id": "image-1",
+                "name": "sample.png",
+                "mimeType": "image/png",
+                "sizeBytes": 68,
+                "dataUrl": "data:image/png;base64,ZmFrZQ==",
+                "createdAt": "2026-05-22T00:00:00Z",
+            }
+        ],
+    )
+    agent = AgentFrameworkAgent(
+        task=task,
+        client=object(),
+        agent_name="test",
+        model="test-model",
+    )
+
+    signature_with_attachment = agent._get_agent_signature()
+    task.attachments = []
+
+    assert agent._get_agent_signature() == signature_with_attachment

--- a/tests/unit_tests/test_agentframework_configure.py
+++ b/tests/unit_tests/test_agentframework_configure.py
@@ -189,8 +189,8 @@ def test_agentframework_pool_agent_naming(agentframework_module):
     agent1 = backend.create_agent(task=task)
     agent2 = backend.create_agent(task=task)
 
-    assert agent1.agent_name == "af_agent_1"
-    assert agent2.agent_name == "af_agent_2"
+    assert agent1.agent_key == "af_agent_1"
+    assert agent2.agent_key == "af_agent_2"
 
 
 def test_responses_api_without_flag_raises_error(agentframework_module):
@@ -224,8 +224,8 @@ def test_agentframework_pool_create_agent_naming(agentframework_module):
 
     # Create first agent
     agent1 = backend.create_agent(task=task)
-    assert "_1" in agent1.agent_name
+    assert "_1" in agent1.agent_key
 
     # Create second agent
     agent2 = backend.create_agent(task=task)
-    assert "_2" in agent2.agent_name
+    assert "_2" in agent2.agent_key

--- a/tests/unit_tests/test_experiment_agent_sessions.py
+++ b/tests/unit_tests/test_experiment_agent_sessions.py
@@ -1,0 +1,104 @@
+from typing import Any, Optional
+
+from charge.clients.agent_factory import Agent, AgentBackend, AgentFactory
+from charge.experiments.experiment import Experiment
+from charge.experiments.memory import Memory
+from charge.tasks.task import Task
+
+
+class DummyAgent(Agent):
+    def __init__(self, task: Optional[Task], **kwargs):
+        super().__init__(task, **kwargs)
+        self.saved_memory = ""
+        self.loaded_memory = ""
+
+    def run(self, reasoning_callback=None, **kwargs) -> str:
+        return "ok"
+
+    def get_context_history(self) -> list:
+        return []
+
+    def load_memory(self, json_str: str) -> None:
+        self.loaded_memory = json_str
+        self.saved_memory = json_str
+
+    def save_memory(self) -> str:
+        return self.saved_memory
+
+    def get_model_info(self) -> dict[str, Any]:
+        return {"backend": "dummy", "model": "dummy-model"}
+
+
+class DummyBackend(AgentBackend):
+    def __init__(self):
+        super().__init__(
+            model="dummy-model",
+            api_key=None,
+            base_url=None,
+            reasoning_effort=None,
+            model_kwargs=None,
+            backend="dummy",
+        )
+
+    def create_agent(
+        self,
+        task: Optional[Task],
+        *,
+        agent_name: Optional[str] = None,
+        memory: Optional[Memory] = None,
+        **kwargs,
+    ) -> Agent:
+        return DummyAgent(task=task, **kwargs)
+
+
+def test_experiment_saves_and_rehydrates_raw_agent_sessions():
+    AgentFactory.register_backend("dummy_sessions", DummyBackend())
+    experiment = Experiment(task=None)
+    task = Task(system_prompt="System", user_prompt="Hello")
+
+    agent = experiment.create_agent_with_experiment_state(
+        task,
+        backend="dummy_sessions",
+        agent_key="molecule:node_1",
+        agent_metadata={"title": "Molecule node_1"},
+    )
+    assert isinstance(agent, DummyAgent)
+    agent.saved_memory = '{"state":{"in_memory":{"messages":[{"role":"user"}]}}}'
+
+    state = experiment.save_state()
+
+    assert state["agentSessions"]["molecule:node_1"]["memory"] == agent.saved_memory
+    assert (
+        state["agentSessions"]["molecule:node_1"]["task"]["system_prompt"] == "System"
+    )
+    experiment.agent_registry["molecule:node_1"]["messageMetadata"] = {
+        "0": {"label": "Chat message"}
+    }
+    state = experiment.save_state()
+    assert (
+        state["agentSessions"]["molecule:node_1"]["messageMetadata"]["0"]["label"]
+        == "Chat message"
+    )
+    assert (
+        state["agentSessions"]["molecule:node_1"]["metadata"]["title"]
+        == "Molecule node_1"
+    )
+    assert (
+        state["agentSessions"]["molecule:node_1"]["modelInfo"]["model"] == "dummy-model"
+    )
+
+    restored = Experiment(task=None)
+    restored.load_state(state)
+    restored_agent = restored.create_agent_with_experiment_state(
+        Task(system_prompt="System", user_prompt="Continue"),
+        backend="dummy_sessions",
+        agent_key="molecule:node_1",
+        agent_metadata={"subtitle": "CCO"},
+    )
+
+    assert isinstance(restored_agent, DummyAgent)
+    assert restored_agent.loaded_memory == agent.saved_memory
+    restored_state = restored.save_state()
+    restored_metadata = restored_state["agentSessions"]["molecule:node_1"]["metadata"]
+    assert restored_metadata["title"] == "Molecule node_1"
+    assert restored_metadata["subtitle"] == "CCO"

--- a/tests/unit_tests/test_experiment_agent_sessions.py
+++ b/tests/unit_tests/test_experiment_agent_sessions.py
@@ -29,7 +29,7 @@ class DummyAgent(Agent):
         self.saved_memory = ""
         self.loaded_memory = ""
 
-    def run(self, reasoning_callback=None, **kwargs) -> str:
+    def run(self, **kwargs) -> str:
         return "ok"
 
     def load_memory(self, json_str: str) -> None:

--- a/tests/unit_tests/test_experiment_agent_sessions.py
+++ b/tests/unit_tests/test_experiment_agent_sessions.py
@@ -7,6 +7,7 @@ from charge.clients.agent_factory import (
     AgentBackend,
     AgentCallbackType,
     AgentFactory,
+    AgentInstructionSnapshot,
     DEFAULT_BACKEND,
 )
 from charge.experiments.experiment import Experiment
@@ -86,6 +87,9 @@ def test_experiment_saves_and_rehydrates_raw_agent_sessions():
         assert isinstance(agent, DummyAgent)
         assert agent.agent_key == "molecule:node_1"
         agent.saved_memory = '{"state":{"in_memory":{"messages":[{"role":"user"}]}}}'
+        agent.instruction_history = [
+            AgentInstructionSnapshot(message_count=1, instructions="System")
+        ]
 
         state = experiment.save_state()
 
@@ -94,13 +98,16 @@ def test_experiment_saves_and_rehydrates_raw_agent_sessions():
             state["agentSessions"]["molecule:node_1"]["task"]["system_prompt"]
             == "System"
         )
+        assert state["agentSessions"]["molecule:node_1"]["instructionHistory"] == [
+            {"messageCount": 1, "instructions": "System"}
+        ]
         assert "metadata" not in state["agentSessions"]["molecule:node_1"]
         assert "messageMetadata" not in state["agentSessions"]["molecule:node_1"]
+        assert "agentKey" not in state["agentSessions"]["molecule:node_1"]
         runtime_config = state["agentSessions"]["molecule:node_1"]["runtimeConfig"]
-        assert runtime_config["agentKey"] == "molecule:node_1"
         assert "agentName" not in runtime_config
         assert runtime_config["backend"] == "dummy"
-        assert set(runtime_config) == {"agentKey", "backend", "model"}
+        assert set(runtime_config) == {"backend", "model"}
         assert (
             state["agentSessions"]["molecule:node_1"]["modelInfo"]["model"]
             == "dummy-model"
@@ -111,6 +118,9 @@ def test_experiment_saves_and_rehydrates_raw_agent_sessions():
         restored_agent = restored.agent_registry["molecule:node_1"].agent
         assert isinstance(restored_agent, DummyAgent)
         assert restored_agent.loaded_memory == agent.saved_memory
+        assert restored_agent.instruction_history == [
+            AgentInstructionSnapshot(message_count=1, instructions="System")
+        ]
 
         restored_agent = restored.create_agent_with_experiment_state(
             Task(system_prompt="System", user_prompt="Continue"),
@@ -135,9 +145,7 @@ def test_experiment_load_state_rejects_backend_mismatch():
         "items": [],
         "agentSessions": {
             "molecule:node_1": {
-                "agentKey": "molecule:node_1",
                 "runtimeConfig": {
-                    "agentKey": "molecule:node_1",
                     "backend": "other",
                     "model": "dummy-model",
                 },

--- a/tests/unit_tests/test_experiment_agent_sessions.py
+++ b/tests/unit_tests/test_experiment_agent_sessions.py
@@ -1,22 +1,35 @@
 from typing import Any, Optional
 
-from charge.clients.agent_factory import Agent, AgentBackend, AgentFactory
+import pytest
+
+from charge.clients.agent_factory import (
+    Agent,
+    AgentBackend,
+    AgentCallbackType,
+    AgentFactory,
+    DEFAULT_BACKEND,
+)
 from charge.experiments.experiment import Experiment
 from charge.experiments.memory import Memory
 from charge.tasks.task import Task
 
 
 class DummyAgent(Agent):
-    def __init__(self, task: Optional[Task], **kwargs):
-        super().__init__(task, **kwargs)
+    def __init__(
+        self,
+        task: Optional[Task],
+        *,
+        agent_key: Optional[str] = None,
+        callback: AgentCallbackType = None,
+        **kwargs,
+    ):
+        super().__init__(task, callback=callback, **kwargs)
+        self.agent_key = agent_key
         self.saved_memory = ""
         self.loaded_memory = ""
 
     def run(self, reasoning_callback=None, **kwargs) -> str:
         return "ok"
-
-    def get_context_history(self) -> list:
-        return []
 
     def load_memory(self, json_str: str) -> None:
         self.loaded_memory = json_str
@@ -44,61 +57,102 @@ class DummyBackend(AgentBackend):
         self,
         task: Optional[Task],
         *,
-        agent_name: Optional[str] = None,
+        agent_key: Optional[str] = None,
         memory: Optional[Memory] = None,
+        callback: AgentCallbackType = None,
         **kwargs,
     ) -> Agent:
-        return DummyAgent(task=task, **kwargs)
+        return DummyAgent(task=task, agent_key=agent_key, callback=callback, **kwargs)
 
 
 def test_experiment_saves_and_rehydrates_raw_agent_sessions():
-    AgentFactory.register_backend("dummy_sessions", DummyBackend())
+    original_default_backend = AgentFactory.backends.get(DEFAULT_BACKEND)
+    AgentFactory.register_backend(DEFAULT_BACKEND, DummyBackend())
     experiment = Experiment(task=None)
     task = Task(system_prompt="System", user_prompt="Hello")
 
-    agent = experiment.create_agent_with_experiment_state(
-        task,
-        backend="dummy_sessions",
-        agent_key="molecule:node_1",
-        agent_metadata={"title": "Molecule node_1"},
-    )
-    assert isinstance(agent, DummyAgent)
-    agent.saved_memory = '{"state":{"in_memory":{"messages":[{"role":"user"}]}}}'
+    try:
+        with pytest.raises(TypeError, match="does not accept backend"):
+            experiment.create_agent_with_experiment_state(
+                task,
+                agent_key="molecule:node_1",
+                backend="dummy_sessions",
+            )
 
-    state = experiment.save_state()
+        agent = experiment.create_agent_with_experiment_state(
+            task,
+            agent_key="molecule:node_1",
+        )
+        assert isinstance(agent, DummyAgent)
+        assert agent.agent_key == "molecule:node_1"
+        agent.saved_memory = '{"state":{"in_memory":{"messages":[{"role":"user"}]}}}'
 
-    assert state["agentSessions"]["molecule:node_1"]["memory"] == agent.saved_memory
-    assert (
-        state["agentSessions"]["molecule:node_1"]["task"]["system_prompt"] == "System"
-    )
-    experiment.agent_registry["molecule:node_1"]["messageMetadata"] = {
-        "0": {"label": "Chat message"}
+        state = experiment.save_state()
+
+        assert state["agentSessions"]["molecule:node_1"]["memory"] == agent.saved_memory
+        assert (
+            state["agentSessions"]["molecule:node_1"]["task"]["system_prompt"]
+            == "System"
+        )
+        assert "metadata" not in state["agentSessions"]["molecule:node_1"]
+        assert "messageMetadata" not in state["agentSessions"]["molecule:node_1"]
+        runtime_config = state["agentSessions"]["molecule:node_1"]["runtimeConfig"]
+        assert runtime_config["agentKey"] == "molecule:node_1"
+        assert "agentName" not in runtime_config
+        assert runtime_config["backend"] == "dummy"
+        assert set(runtime_config) == {"agentKey", "backend", "model"}
+        assert (
+            state["agentSessions"]["molecule:node_1"]["modelInfo"]["model"]
+            == "dummy-model"
+        )
+
+        restored = Experiment(task=None)
+        restored.load_state(state)
+        restored_agent = restored.agent_registry["molecule:node_1"].agent
+        assert isinstance(restored_agent, DummyAgent)
+        assert restored_agent.loaded_memory == agent.saved_memory
+
+        restored_agent = restored.create_agent_with_experiment_state(
+            Task(system_prompt="System", user_prompt="Continue"),
+            agent_key="molecule:node_1",
+        )
+
+        assert isinstance(restored_agent, DummyAgent)
+        assert restored_agent.loaded_memory == agent.saved_memory
+        restored_state = restored.save_state()
+        assert "metadata" not in restored_state["agentSessions"]["molecule:node_1"]
+    finally:
+        if original_default_backend is None:
+            AgentFactory.backends.pop(DEFAULT_BACKEND, None)
+        else:
+            AgentFactory.register_backend(DEFAULT_BACKEND, original_default_backend)
+
+
+def test_experiment_load_state_rejects_backend_mismatch():
+    original_default_backend = AgentFactory.backends.get(DEFAULT_BACKEND)
+    AgentFactory.register_backend(DEFAULT_BACKEND, DummyBackend())
+    state = {
+        "items": [],
+        "agentSessions": {
+            "molecule:node_1": {
+                "agentKey": "molecule:node_1",
+                "runtimeConfig": {
+                    "agentKey": "molecule:node_1",
+                    "backend": "other",
+                    "model": "dummy-model",
+                },
+                "memory": "",
+                "modelInfo": {"backend": "other", "model": "dummy-model"},
+                "task": Task(system_prompt="System", user_prompt="Hello").to_json(),
+            }
+        },
     }
-    state = experiment.save_state()
-    assert (
-        state["agentSessions"]["molecule:node_1"]["messageMetadata"]["0"]["label"]
-        == "Chat message"
-    )
-    assert (
-        state["agentSessions"]["molecule:node_1"]["metadata"]["title"]
-        == "Molecule node_1"
-    )
-    assert (
-        state["agentSessions"]["molecule:node_1"]["modelInfo"]["model"] == "dummy-model"
-    )
 
-    restored = Experiment(task=None)
-    restored.load_state(state)
-    restored_agent = restored.create_agent_with_experiment_state(
-        Task(system_prompt="System", user_prompt="Continue"),
-        backend="dummy_sessions",
-        agent_key="molecule:node_1",
-        agent_metadata={"subtitle": "CCO"},
-    )
-
-    assert isinstance(restored_agent, DummyAgent)
-    assert restored_agent.loaded_memory == agent.saved_memory
-    restored_state = restored.save_state()
-    restored_metadata = restored_state["agentSessions"]["molecule:node_1"]["metadata"]
-    assert restored_metadata["title"] == "Molecule node_1"
-    assert restored_metadata["subtitle"] == "CCO"
+    try:
+        with pytest.raises(RuntimeError, match="mismatched backend"):
+            Experiment(task=None).load_state(state)
+    finally:
+        if original_default_backend is None:
+            AgentFactory.backends.pop(DEFAULT_BACKEND, None)
+        else:
+            AgentFactory.register_backend(DEFAULT_BACKEND, original_default_backend)


### PR DESCRIPTION
- Every Experiment holds a set of agents saved by their name.
- Agent name has been renamed to agent_key to ensure uniqueness is clear
- Agent callback handler well-defined and not popped from unstructured kwargs