### PR TITLE
Bugfix agent framework build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ ollama = ["ollama>=0.5.0"]
 gemini = ["google-genai >=1.19.0"]
 agentframework = [
     # Can't use basic `agent-framework` install since hyperlight breaks install on HPCs
-    "agent-framework-core>=1.1.1",
-    "agent-framework-openai>=1.1.1",
-    "agent-framework-orchestrations==1.0.0",
+    "agent-framework-core==1.1.1",
+    "agent-framework-openai==1.1.1",
+    "agent-framework-orchestrations",
     # The rest of the agent-framework packages are in pre-release
     "agent-framework-a2a",
     "agent-framework-ag-ui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,6 @@ agentframework = [
     # Can't use basic `agent-framework` install since hyperlight breaks install on HPCs
     "agent-framework-core==1.1.1",
     "agent-framework-openai==1.1.1",
-    "agent-framework-orchestrations",
-    # The rest of the agent-framework packages are in pre-release
-    "agent-framework-a2a",
-    "agent-framework-ag-ui",
-    "agent-framework-anthropic",
-    "agent-framework-bedrock",
-    "agent-framework-claude",
-    "agent-framework-ollama",
     "openai>=2.0.0",
     "tiktoken>=0.10.0",
     # Pin opentelemetry to a known good version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,24 @@ include = ["charge*"]
 [project.optional-dependencies]
 ollama = ["ollama>=0.5.0"]
 gemini = ["google-genai >=1.19.0"]
-# Pin opentelemetry to a known good version
-agentframework = ["agent-framework==1.1.1", "agent-framework-openai==1.1.1", "openai>=2.0.0", "tiktoken>=0.10.0", "opentelemetry-semantic-conventions-ai==0.4.13"]
+agentframework = [
+    # Can't use basic `agent-framework` install since hyperlight breaks install on HPCs
+    "agent-framework-core>=1.1.1",
+    "agent-framework-openai>=1.1.1",
+    "agent-framework-orchestrations==1.0.0",
+    # The rest of the agent-framework packages are in pre-release
+    "agent-framework-a2a",
+    "agent-framework-ag-ui",
+    "agent-framework-anthropic",
+    "agent-framework-bedrock",
+    "agent-framework-claude",
+    "agent-framework-ollama",
+    "openai>=2.0.0",
+    "tiktoken>=0.10.0",
+    # Pin opentelemetry to a known good version
+    "opentelemetry-semantic-conventions-ai==0.4.13"
+]
+
 test = ["pytest", "pytest-asyncio", "pytest-mock", "responses", "httpx", "requests-mock"]
 
 # Define a set of optional packages for use when deploying persistent data services


### PR DESCRIPTION
To avoid build problems with all of agent frameworks supplemental 
libraries, limit the scope of which packages are selected.